### PR TITLE
Update 3.0 and 3.1:

### DIFF
--- a/2.6/amplio_earth.tilespec
+++ b/2.6/amplio_earth.tilespec
@@ -9,7 +9,7 @@ name = "amplio_earth"
 priority = 30
 
 ; There`s no separate versioning in tilesets part of main freeciv distribution
-version = "2.6_2024_05"
+version = "2.6_2024_05b"
 
 ; Summary and full description of the tileset.
 summary = _("Large isometric tileset based on Amplio.")

--- a/2.6/amplio_earth/README.tileset_civ2civ3_earth
+++ b/2.6/amplio_earth/README.tileset_civ2civ3_earth
@@ -3,7 +3,7 @@ Amplio Earth Tileset for Freeciv v2.6
 =====================================
 
 Tileset based on Amplio2 (by GriffonSpade), but with small flags, small resources, and colors more similar to Amplio (and to minimap).
-Compiled by Bardo and released under GPLv2 license (see each .spec file for detailed credits).
+Edited by Bardo and released under GPLv2 license (see each .spec file for detailed credits).
 
 Modded from Amplio2:
 - mountains, with colors from Amplio mountains.

--- a/2.6/civ2civ3_earth-2.6.modpack
+++ b/2.6/civ2civ3_earth-2.6.modpack
@@ -3,7 +3,7 @@ options = "+Freeciv-2.6-modpack"
 baseURL = "."
 name    = "Civ2civ3_Earth"
 type    = "Modpack"
-version = "2024_05"
+version = "2024_05b"
 
 [files]
 list =

--- a/2.6/civ2civ3_earth/NEWS.ruleset_civ2civ3_earth
+++ b/2.6/civ2civ3_earth/NEWS.ruleset_civ2civ3_earth
@@ -40,7 +40,7 @@ Terrains:
 - Some units get additional veteran levels when certain resources are available in the city:
   - Strategic resources (Horses, Ivory; Rubber, Aluminum, Uranium): +1 veteran level for certain units built in the city (or in a city linked by trade route).
   - Key resources (Iron, Niter, Oil). For units that require Iron, Niter: -1 veteran level for each one of these resources that is not available in the city. For units that require Iron/Oil: -1 veteran level if none of these resources are available in the city.
-- Power Plants require Oil resource available in the city. Nuclear Plants and Manhattan Project require Uranium. Apollo Program requires Aluminum.
+* Power Plants require Oil resource available in the city. Nuclear Plants and Manhattan Project require Uranium. Apollo Program no longer requires Aluminum.
 - Added Natural Wonders, that produce +2 Luxury points in the tile, and increase a bit the risk of natural disasters in a city. Marked with a text label and a red flag icon on the map. They are destroyed when the underlying terrain is transformed.
 
 Culture:
@@ -113,7 +113,7 @@ Naval units:
 
 Wonders:
 - Readjusted effects and obsolescence of many wonders. See the table (in README file).
-- The construction of a wonder no longer requires the presence of other buildings in the city. This way, most wonders appear as available in every city, and it is easier to keep track of them. However, some wonders still require another building in the city in order to get the bonus, and some of them require adjacent water ("Lighthouse", "Magellan's Expedition", "Hoover Dam") or specific resources available in the city ("Manhattan Project" and "Apollo Program").
+- The construction of a wonder no longer requires the presence of other buildings in the city. This way, most wonders appear as available in every city, and it is easier to keep track of them. However, some wonders still require another building in the city in order to get the bonus, and some of them require adjacent water ("Lighthouse", "Magellan's Expedition", "Hoover Dam") or a resource available in the city ("Manhattan Project").
 - Continental range: "J.S. Bach's Cathedral", "Great Wall" and "Sun Tzu's War Academy" affects only to cities of the same continent.
 - Global range: some minor effects, that may affect every player, added to "Cure For Cancer", "Internet", and "Women's Suffrage".
 * Every wonder produces as much culture per turn as its building cost/100.

--- a/2.6/civ2civ3_earth/README.ruleset_civ2civ3_earth
+++ b/2.6/civ2civ3_earth/README.ruleset_civ2civ3_earth
@@ -1,5 +1,5 @@
 ============================================================
-Civ2Civ3 Earth Ruleset for Freeciv v2.6 (Updated 05-2024)
+Civ2Civ3 Earth Ruleset for Freeciv v2.6 (Updated 12-2024)
 ============================================================
 
 "civ2civ3_earth" is a fork of the ruleset civ2civ3 (shipped with Freeciv since 2.5), from the same author. It includes new features, tries to improve balance, and is more suitable for playing on Earth maps, or similar scenarios. It includes its own tileset "amplio_earth", and a world map scenario, adapted to be played with these rules.
@@ -47,9 +47,9 @@ CORE CHANGES:
 
 - Allowed 1 trade route per city (2 after the discovery of The Corporation). Removed the one time revenues, and reduced the ongoing revenues. Trade routes with foreign cities receive 50% of the income, and only if the cities are allies (or on the same team).
 
-- Every unit (except Settlers, Migrants, and Fanatics, which cost population to build) pays some kind of upkeep cost. Some governments pay shields as upkeep, and others pay coins (similar to civ3), but not both.
+- Every unit pays some kind of upkeep cost (except Settlers, Migrants, and Fanatics, which cost population to build). Some governments pay shields as upkeep, and others pay coins (similar to civ3), but not both.
 
-- Most units also require upkeep in Food, except for Workers/Engineers, Diplomat/Spy, Caravan/Freight, Explorer/AWACS, and Cruise Missile/Nuclear.
+- Most units also require upkeep in Food (except for Workers/Engineers, Diplomat/Spy, Caravan/Freight, Explorer/AWACS, and Cruise Missile/Nuclear).
   A city can support for free as many units (with upkeep in Food) as its population size (min 4, max 20). Additional units cause waste of Food. If the city shrinks due to starvation, one of those extra units will be disbanded.
 
 - Units lose one veteran level when upgraded.
@@ -220,7 +220,7 @@ Mountains -(36)---> Hills
 
 - Some units get additional veteran levels when certain resources are available in the city:
 
-  - Strategic resources (Horses, Ivory; Rubber, Aluminum, Uranium): +1 veteran level for certain units built in the city (or in any city linked by trade route).
+  - Strategic resources (Horses, Ivory; Rubber, Aluminum, Uranium): +1 veteran level for certain units built in the city (or in a city linked by trade route).
 
   - Key resources (Iron, Niter, Oil). For units that require Iron, Niter: -1 veteran level for each one of these resources that is not available in the city. For units that require Iron/Oil: -1 veteran level if none of these resources are available in the city.
 
@@ -324,11 +324,11 @@ TIP: There is some hurry to get Monarchy or Republic (or to build Pyramids), in 
 - Republic gets a bonus to trade on irrigated land; but it has a senate, units no longer impose martial law, and units outside your borders may cause unhappiness more easily.
 - Fundamentalism gets a significant bonus to gold production, especially useful when terrain is not favorable; but it receives no revenue from city celebrations, and science production is low even with taxes on science at maximum.
 - Democracy gets the same trade bonus on irrigated land as Republic, and reduces the corruption and waste caused by distance from the palace; but it has a senate, and it doubles the unhappiness caused by units outside your borders.
-  It can be the best government once city celebrations generate revenue (when they produce more trade than required to celebrate), especially when cities are surrounded by plains, grasslands or swamps.
+  It can be the best government once city celebrations generate revenue (when they produce more trade than required to celebrate), especially when cities are surrounded by plains, with some forests/hills on rivers.
 - Federation eliminates the corruption and waste caused by distance from the palace, and its bonus to luxury production allows cities to celebrate more easily; but it does not get the trade bonus from irrigated land.
   It is a good alternative to Democracy for larger empires or more aggressive wars, especially when cities are surrounded by sea (less irrigated or mined land, but more trade).
 - Communism also eliminates the corruption and waste caused by distance from the palace, and reduces considerably the gold paid for upkeep of buildings; but it receives no revenue from city celebrations.
-  It is a good alternative to Federation for post-industrial large empires, especially when cities are surrounded by hills/mountains or jungles/forests (less trade, but more production).
+  It is a good alternative to Federation for post-industrial large empires, especially when cities are surrounded by hills, mountains or jungles (less trade, but more production).
 - Fascism avoids the upkeep costs of many buildings like Communism, increases the chance of units becoming veteran, and it is the only modern government whose units can't cause unhappiness; but corruption and waste caused by distance is not eliminated.
   It is a good alternative for militaristic nations, especially when city celebrations are not worth the cost.
 
@@ -435,23 +435,21 @@ Recycling Center  140   2      -50%/-25%
 DEFENSE:
 --------
 
-- Halved the terrain defense bonuses, now more similar to civ3 values:
-
-TERRAIN                   NEW      CIV2
-Forest/Jungle/Swamp       +25%     +50%
-Hills                     +50%     +100%
-Mountains                 +100%    +200%
-
-RIVER                     +25%     +50%
-
 VETERAN
 Regular                   +25%
-Veteran                   +50%     (=)
-Hardened                  +75%     (=)
-Elite                     +100%    (=)
+Veteran                   +50%
+Hardened                  +75%
+Elite                     +100%
 
-FORTIFIED                 +50%     (=)
+FORTIFIED                 +50%
 (only military ground units can fortify; inside cities, they are always considered fortified)
+
+TERRAIN
+Forest/Jungle/Swamp       +25%
+Hills                     +50%
+Mountains                 +100%
+
+RIVER                     +25%
 
 BASE             VS LAND  VS SEA   VS AIR   VS MISSILE
 Fort             +50%     +50%      -        -
@@ -476,7 +474,9 @@ SDI Defense       -        -        -       +100%
 Great Wall       +50%      -        -        -
 
 
-- Naval units on Deep Ocean, or shallow Ocean adjacent to a Naval Mine, receive a +50% defense bonus against Sea units (not against Submarines).
+- Halved the terrain defense bonuses, now more similar to civ3 values.
+
+- Naval units on Deep Ocean, or shallow Ocean adjacent to a Naval Mine, receive a +50% defense bonus against other naval units (except against Submarines).
 
 - Every city of any size receives an inherent +50% defense bonus against all ground and naval units (same as a fort).
 
@@ -491,13 +491,12 @@ Great Wall       +50%      -        -        -
 Total Defense = (UNIT DEFENSE) * (100+TERRAIN)/100 * (100+RIVER)/100 * (100+CITY+BASE)/100 * (100+FORTIFIED)/100 * (100+VETERAN)/100
 (Same as classic/civ2 rules).
 
-EXAMPLE: Riflemen fortified in a fortress, on mountains, with a river, will get a total defense of 30 against land attacks:
+EXAMPLE: Riflemen fortified in a fortress, on mountains, will get a total defense of 24 against land attacks:
 
          Riflemen: defense 4
          Fortified (+50%): 4 + 2 = 6
          In Fortress (+100%):      6 + 6 = 12
-         On Mountains (+100%):             12 + 12 = 24
-         With River (+25%):                          24 + 6 = 30.
+         On Mountains (+100%):             12 + 12 = 24.
 
 EXAMPLE: Riflemen in a size 9 city, with walls, on hills, will get a total defense of 27 against land attacks:
 
@@ -640,11 +639,11 @@ In full base              *(+24%)    34% Fortress                  34% Airbase
 RESTING INSIDE CITY  (HP REGEN %)    LAND           SEA            AIR
 Without improvement       #(+34%)    44%            44%            34%
 With improvement          *(+50%)    60% Barracks   60% Port       50% Airport
-(non mechanized)                    +15% Hospital
+(non wheeled)                       +15% Hospital
 
 EVERY TURN
 On plains, grassland or shallow ocean, with knowledge of:
-  Medicine (non mechanized units)                   +2 HP
+  Medicine (non wheeled ground units)               +2 HP
   Physics (wheeled or naval units)                  +2 HP
 
 On any oceanic or glacier tile adjacent to a Storm: -4 HP
@@ -742,7 +741,7 @@ Gives to all your Hydro Plants the same effect as Solar Plants (-25% pollution c
 
 --- (#)"Manhattan Project" 600. Requires Uranium:
 # Enables Nuclear units for every nation.
---- (#)"Apollo Program" 600. Requires Aluminum:
+--- (#)"Apollo Program" 600:
 Makes the entire map (but not the units) permanently visible for the owner.
 # Enables space race for every nation.
 -=- (#)"United Nations" 600:

--- a/2.6/civ2civ3_earth/buildings.ruleset
+++ b/2.6/civ2civ3_earth/buildings.ruleset
@@ -1397,7 +1397,6 @@ genus		= "GreatWonder"
 reqs	=
     { "type", "name", "range"
       "Tech", "Space Flight", "Player"
-      "Extra", "Aluminum", "Traderoute"
     }
 graphic	= "b.apollo_program"
 graphic_alt	= "-"

--- a/2.6/civ2civ3_earth/effects.ruleset
+++ b/2.6/civ2civ3_earth/effects.ruleset
@@ -549,6 +549,7 @@ reqs    =
     }
 
 ; City: against every land and sea
+; City defense is equal to a Fort
 [effect_city_defense_0]
 type    = "Defend_Bonus"
 value   = 50
@@ -568,6 +569,7 @@ reqs    =
     }
 
 ; City (size > 8): against every land and sea
+; 50 + 50 = 100
 [effect_city_defense_1]
 type    = "Defend_Bonus"
 value   = 50
@@ -2163,26 +2165,6 @@ reqs    =
 ;      "Gov", "Federation", "Player", FALSE
 ;      "Gov", "Republic", "Player", FALSE
 ;      "Gov", "Democracy", "Player", FALSE
-    }
-
-; Celebration: only city center tile
-[effect_gov_tile_bonus_celebrate_center]
-type    = "Output_Inc_Tile_Celebrate"
-value   = 1
-reqs    =
-    { "type", "name", "range", "present"
-      "OutputType", "Trade", "Local", TRUE
-      "CityTile", "Center", "Local", TRUE
-      "Gov", "Anarchy", "Player", FALSE
-      "Gov", "Tribal", "Player", FALSE
-      "Gov", "Despotism", "Player", FALSE
-      "Gov", "Monarchy", "Player", FALSE
-;      "Gov", "Fascism", "Player", FALSE
-;      "Gov", "Communism", "Player", FALSE
-;      "Gov", "Fundamentalism", "Player", FALSE
-      "Gov", "Federation", "Player", FALSE
-      "Gov", "Republic", "Player", FALSE
-      "Gov", "Democracy", "Player", FALSE
     }
 
 [effect_vision_tribal]

--- a/2.6/civ2civ3_earth/game.ruleset
+++ b/2.6/civ2civ3_earth/game.ruleset
@@ -25,7 +25,7 @@ description_file = "civ2civ3_earth/README.ruleset_civ2civ3_earth"
 name = _("Civ2Civ3 Earth ruleset")
 
 ; There`s no separate versioning in rulesets part of main freeciv distribution
-version = "2.6_2024_05"
+version = "2.6_2024_05b"
 
 ; Summary of the ruleset
 summary = _("\

--- a/2.6/civ2civ3_earth/governments.ruleset
+++ b/2.6/civ2civ3_earth/governments.ruleset
@@ -127,7 +127,7 @@ _("\
 * Base corruption is 30% (the highest under any government). This\
  increases by 2% for each tile of distance from the capital.\n\
 * There is no base level of production waste, but it increases\
- by 2% for each tile of distance from the capital.\n\
+ by 2% for each tile of distance from the capital.\
 ")
 
 ;------------------------------------------------------------------------
@@ -232,8 +232,8 @@ Communism eliminates the corruption and waste caused by distance from\
  buildings; but it does not get the trade bonus from irrigated land\
  or city celebrations.\
 "), _("\
-It is a good alternative to Federation for large empires, especially\
- when cities are surrounded by hills, mountains, jungles or forests\
+It is a good alternative to Federation for post-industrial large empires,\
+ especially when cities are surrounded by hills, mountains or jungles\
  (less trade, but more production).\
 "),
 ; /* xgettext:no-c-format */
@@ -281,8 +281,8 @@ Improvements that normally convert unhappy citizens to content\
  of people they would convert.\
 "), _("\
 Fundamentalism gets a significant bonus to gold production, especially\
- useful when terrain is not favorable for trade; but city celebrations\
- give no revenues, and science production is low even with taxes on\
+ useful when terrain is not favorable; but it receives no revenue from\
+ city celebrations, and science production is low even with taxes on\
  science at maximum.\
 "),
 ; /* xgettext:no-c-format */
@@ -325,7 +325,7 @@ Federation eliminates the corruption and waste caused by distance from\
 "), _("\
 It is a good alternative to Democracy for larger empires or more\
  aggressive wars, especially when cities are surrounded by sea (less\
- land, but more trade).\
+ irrigated or mined land, but more trade).\
 "),
 ; /* xgettext:no-c-format */
 _("\
@@ -339,7 +339,7 @@ _("\
  each further unit causes 1 unhappy citizen.\n\
 * There is no corruption.\n\
 * Base production waste is 30%, but is not affected by distance to the\
- capital.\n\
+ capital.\
 ")
 
 ;------------------------------------------------------------------------
@@ -381,7 +381,7 @@ irrigation.\n\
 * Base corruption is 25%. This increases by 2% for each tile of distance\
  from the capital.\n\
 * Base production waste is 5%. This increases by 2% for each tile of\
- distance from the capital.\
+ distance from the capital.\n\
 * Has a senate that may prevent declaration of war.\
 ")
 
@@ -409,8 +409,9 @@ Democracy gets the same trade bonus on irrigated land as Republic,\
  palace; but it has a senate, and it doubles the unhappiness caused\
  by units outside your borders.\
 "), _("\
-It is the best government once city celebrations give revenues (when\
- they produce more trade than the required to celebrate).\
+It can be the best government once city celebrations generate revenue\
+ (when they produce more trade than the required to celebrate),\
+ especially when cities are surrounded by plains and rivers.\
 "),
 ; /* xgettext:no-c-format */
 _("\
@@ -474,7 +475,7 @@ _("\
 * Base corruption is 15%. This increases by 1% for each tile of distance\
  from the capital.\n\
 * Base production waste is 15%. This increases by 1% for each tile of\
- distance from the capital.\n\
+ distance from the capital.\
 ")
 
 ; /* <-- avoid gettext warnings

--- a/2.6/civ2civ3_earth/techs.ruleset
+++ b/2.6/civ2civ3_earth/techs.ruleset
@@ -476,7 +476,6 @@ helptext = _("\
 Aluminum resources produce 2 extra shields in the tile where they are \
 located.\
 "), _("\
-Aluminum is required in a city to build the wonder Apollo Program. \
 Cities with available Aluminum build Carrier, AEGIS Cruiser, Cruise \
 Missile, Fighter and Bomber units with one extra veteran level.\
 ")

--- a/2.6/civ2civ3_earth/terrain.ruleset
+++ b/2.6/civ2civ3_earth/terrain.ruleset
@@ -1273,7 +1273,7 @@ rmact_gfx_alt  = "-"
 reqs           =
     { "type", "name", "range", "present", "quiet"
       "TerrainFlag", "Wood", "Local", FALSE, TRUE
-      "TerrainClass", "Oceanic", "Local", FALSE, TRUE
+      "TerrainClass", "Land", "Local", TRUE, FALSE
       "UnitClass", "Sea", "Local", FALSE, TRUE
     }
 rmreqs         =
@@ -1307,7 +1307,7 @@ rmact_gfx      = "None"
 rmact_gfx_alt  = "-"
 reqs           =
     { "type", "name", "range", "present", "quiet"
-      "TerrainFlag", "Wood", "Local", TRUE, TRUE
+      "TerrainFlag", "Wood", "Local", TRUE, FALSE
       "UnitClass", "Sea", "Local", FALSE, TRUE
     }
 rmreqs         =
@@ -1337,7 +1337,7 @@ rmact_gfx_alt  = "-"
 reqs           =
     { "type", "name", "range", "present", "quiet"
       "Tech", "Refining", "Player", TRUE, FALSE
-      "TerrainFlag", "Oil", "Local", TRUE, TRUE
+      "TerrainFlag", "Oil", "Local", TRUE, FALSE
       "Extra", "Mine", "Local", TRUE, FALSE
       "UnitClass", "Sea", "Local", FALSE, TRUE
     }
@@ -1490,10 +1490,10 @@ rmact_gfx_alt  = "-"
 ; Note, there are extra restrictions on where farmland can be built
 ; through Irrig_Possible effects
 reqs           =
-    { "type", "name", "range", "present"
-      "Tech", "Refrigeration", "Player", TRUE
-      "Extra", "Irrigation", "Local", TRUE
-      "CityTile", "Center", "Local", FALSE
+    { "type", "name", "range", "present", "quiet"
+      "Tech", "Refrigeration", "Player", TRUE, FALSE
+      "Extra", "Irrigation", "Local", TRUE, FALSE
+      "CityTile", "Center", "Local", FALSE, TRUE
     }
 rmreqs         =
     { "type", "name", "range", "present"
@@ -1991,8 +1991,8 @@ reqs           =
       "Tech", "Explosives", "Player", TRUE, FALSE
       "TerrainClass", "Land", "Local", TRUE, FALSE
       "Terrain", "Glacier", "Local", FALSE, FALSE
-      "Terrain", "Hills", "Local", FALSE, FALSE
       "Terrain", "Mountains", "Local", FALSE, FALSE
+      "Terrain", "Hills", "Local", FALSE, FALSE
       "TerrainClass", "Oceanic", "CAdjacent", TRUE, FALSE
       "UnitFlag", "Settlers", "Local", TRUE, FALSE
     }
@@ -2069,11 +2069,11 @@ rmact_gfx      = "None"
 rmact_gfx_alt  = "-"
 buildable      = FALSE
 conflicts      = "Niter", "Rubber", "Uranium"
-flags          = "TerrChangeRemoves"
+;flags          = "TerrChangeRemoves"
 helptext       = _("\
-Strategic resource, required in a city to build the wonder Apollo \
-Program. Cities with available aluminum build Carrier, AEGIS Cruiser, \
-Cruise Missile, Fighter and Bomber units with one extra veteran level.\
+Strategic resource. Cities with available aluminum build Carrier, \
+AEGIS Cruiser, Cruise Missile, Fighter and Bomber units with one extra \
+veteran level.\
 "), _("\
 With the discovery of Industrialization, aluminum produces 2 extra shields \
 in the tile (hills or tundra).\
@@ -2093,7 +2093,7 @@ rmact_gfx      = "None"
 rmact_gfx_alt  = "-"
 buildable      = FALSE
 conflicts      = "Aluminum", "Rubber", "Uranium"
-flags          = "TerrChangeRemoves"
+;flags          = "TerrChangeRemoves"
 helptext       = _("\
 Strategic resource. Cities without available niter build gunpowder \
 based units with one less veteran level: Musketeers, Riflemen, Alpine \
@@ -2118,7 +2118,7 @@ rmact_gfx      = "None"
 rmact_gfx_alt  = "-"
 buildable      = FALSE
 conflicts      = "Aluminum", "Niter", "Uranium"
-flags          = "TerrChangeRemoves"
+;flags          = "TerrChangeRemoves"
 helptext       = _("\
 Strategic resource. Cities with available rubber build Marines, \
 Paratroopers, Helicopter, Mech. Inf. and Howitzer units with one extra \
@@ -2142,7 +2142,7 @@ rmact_gfx      = "None"
 rmact_gfx_alt  = "-"
 buildable      = FALSE
 conflicts      = "Aluminum", "Niter", "Rubber"
-flags          = "TerrChangeRemoves"
+;flags          = "TerrChangeRemoves"
 helptext       = _("\
 Strategic resource, required in a city to build a Nuclear Plant or \
 the wonder Manhattan Project. Cities with available uranium build \

--- a/3.0/amplio_earth.tilespec
+++ b/3.0/amplio_earth.tilespec
@@ -9,7 +9,7 @@ name = "amplio_earth"
 priority = 30
 
 ; There`s no separate versioning in tilesets part of main freeciv distribution
-version = "3.0_2024_05"
+version = "3.0_2024_05b"
 
 ; Summary and full description of the tileset.
 summary = _("Large isometric tileset based on Amplio.")

--- a/3.0/amplio_earth/README.tileset_civ2civ3_earth
+++ b/3.0/amplio_earth/README.tileset_civ2civ3_earth
@@ -3,7 +3,7 @@ Amplio Earth Tileset for Freeciv v3.0
 =====================================
 
 Tileset based on Amplio2 (by GriffonSpade), but with small flags, small resources, and colors more similar to Amplio (and to minimap).
-Compiled by Bardo and released under GPLv2 license (see each .spec file for detailed credits).
+Edited by Bardo and released under GPLv2 license (see each .spec file for detailed credits).
 
 Modded from Amplio2:
 - mountains, with colors from Amplio mountains.
@@ -53,4 +53,5 @@ Modded from Hexemplio:
 Known issues:
 - Ocean file needs to be adjusted for the lack of E-W blend between land, ocean, and deep ocean.
 I made some minor adjustments, but it is still too noticeable.
+- I suggest to play with the Map Grid enabled (in the View menu).
 

--- a/3.0/ampliohex_earth.tilespec
+++ b/3.0/ampliohex_earth.tilespec
@@ -9,7 +9,7 @@ name = "ampliohex_earth"
 priority = 30
 
 ; There`s no separate versioning in tilesets part of main freeciv distribution
-version = "3.0_2024_05"
+version = "3.0_2024_05b"
 
 ; Summary and full description of the tileset.
 summary = _("Large isometric tileset based on Amplio.")

--- a/3.0/civ2civ3_earth-3.0.mpdl
+++ b/3.0/civ2civ3_earth-3.0.mpdl
@@ -3,7 +3,7 @@ options = "+Freeciv-3.0-mpdl"
 baseURL = "."
 name    = "Civ2civ3_Earth"
 type    = "Modpack"
-version = "2024_05"
+version = "2024_05b"
 
 [files]
 list =

--- a/3.0/civ2civ3_earth/NEWS.ruleset_civ2civ3_earth
+++ b/3.0/civ2civ3_earth/NEWS.ruleset_civ2civ3_earth
@@ -8,6 +8,7 @@ Known issues:
 - If the ruleset is played with a version of Freeciv prior to 3.0.8, the "Investigate city" action may cause a crash to desktop (related to the presence of traded resources in the target city). As an alternative, military units can use the "Bombard" action to see all defending units.
 - The server settings suggested by the ruleset are no longer loaded by default. Due to changes in Freeciv 3.0, now user settings (from freeciv-client-rc) and ruleset settings (from game.ruleset) are mixed in a kind of unpredictable way. I suggest using a clean version of freeciv-client-rc-3.x before starting a new game.
 * This modpack includes 2 custom tilesets, one for square and one for hexagonal topology, but they are no longer loaded by default. The player has to select them manually from the client local options -> Graphics -> Tileset (or by editing the values starting with "default_tileset_" in the file freeciv-client-rc).
+* When playing with hexagonal topology, I suggest enabling the map grid (in the View menu) and increasing the minimum distance between cities (citymindist setting) to 4 in order to force the AI to build better cities.
 
 Fixed bugs:
 - Strategic resources no longer appear on the same tile as other special resources.
@@ -46,7 +47,7 @@ Terrains:
 - Some units get additional veteran levels when certain resources are available in the city:
   - Strategic resources (Horses, Ivory; Rubber, Aluminum, Uranium): +1 veteran level for certain units built in the city (or in a city linked by trade route).
   - Key resources (Iron, Niter, Oil). For units that require Iron, Niter: -1 veteran level for each one of these resources that is not available in the city. For units that require Iron/Oil: -1 veteran level if none of these resources are available in the city.
-- Power Plants require Oil resource available in the city. Nuclear Plants and Manhattan Project require Uranium. Apollo Program requires Aluminum.
+* Power Plants require Oil resource available in the city. Nuclear Plants and Manhattan Project require Uranium. Apollo Program no longer requires Aluminum.
 - Added Natural Wonders, that produce +2 Luxury points in the tile, and increase a bit the risk of natural disasters in a city. Marked with a text label and a red flag icon on the map. They are destroyed when the underlying terrain is transformed.
 
 Culture:
@@ -61,8 +62,8 @@ Governments:
 - New government: Fascism (available with Military Tactics, which requires Leadership and Conscription).
 - Empire Size no longer depends on the government chosen. Every time a new government becomes available, the Empire Size increases by 2, from 4 at the beginning, up to 20 when all governments have been discovered.
 * The number of content citizens, before the first unhappy one appears, is now 5 for most governments; 4 only for Despotism, Monarchy and Fundamentalism; 6 for Democracy and Federation.
-- Corruption and waste by distance are fixed to +2% per tile for ancient governments, +1% for modern governments, and +0% for Federation and Communism; no longer tied to the research of Trade or The Corporation techs.
-- Tribal (available with Warrior Code) gets 3 units per city free of upkeep, and extra vision range for ground units, instead of martial law.
+* Corruption and waste by distance are fixed to +4% per tile for Despotism and Tribalism, +2% for other ancient governments, +1% for modern governments, and +0% for Federation and Communism; no longer tied to the research of Trade or The Corporation techs.
+- Tribalism (available with Warrior Code) gets 3 units per city free of upkeep, and extra vision range for ground units, instead of martial law.
 - Despotism and Monarchy get a bonus to Luxury from the Palace (was Gold). Federation gets +2 Luxury points per city.
 - Republic and Democracy get the +1 Trade bonus only on tiles with an irrigation, and regardless if the tile wasn't producing any trade.
 * Fascism gets a +1 Gold bonus on each tile with a mine (including lumber, oil well and oil platform), instead of buildings free of upkeep.
@@ -73,6 +74,7 @@ Governments:
 - Fundamentalism no longer gets any penalty to Science output. Anarchy doesn't get any penalty to Luxury output.
 
 Techs:
+* Trade: cancels the output per tile penalty under Anarchy, Despotism and Tribalism; no longer tied to The Pyramids wonder or the research of Railroad.
 - Astronomy increases vision range of cities and fortresses. Electricity grants you vision within your borders.
 - Feudalism: allows to upgrade a Fortress to a Castle when it is inside your national borders. Castles protect full stacks from dying when one unit is defeated.
 - Medicine: allows non-wheeled ground units to recover 2 HP per turn, on plains or grassland, even without resting. Physics allows the same for wheeled units (on plains or grassland), and for naval units on shallow ocean.
@@ -129,7 +131,7 @@ Units:
 * Some adjustments to the HP recover rate of units. See the new table (in README file).
 
 Naval units:
-- Defense bonus of +50% in Deep Ocean (or shallow Ocean adjacent to a Naval Mine) against Sea units (not against Submarines).
+* Defense bonus of +50% in Deep Ocean (or shallow Ocean adjacent to a Naval Mine) against naval units (except against Submarines).
 * New unit Sailboat (available with Astronomy), which cannot attack, so it can move inside the borders of peaceful nations. It can enter deep oceans, but cannot end far from shore (on deep ocean surrounded by deep oceans) more than 1 consecutive turn.
 * Trireme was renamed to Galley, which can now enter 1 tile into deep ocean, but cannot enter a deep ocean tile completely surrounded by deep oceans (or by mountains or glaciers, to prevent early discovery of America on some world maps). Galleys lose 1 hit point every turn ended on deep ocean (-10% HP loss as air units).
 * All naval units capable of attacking, also have bombardment capabilities. Galleon attack increased to 2, with a bombard rate of 3 (no longer nonMil).
@@ -141,7 +143,7 @@ Naval units:
 
 Wonders:
 - Readjusted effects and obsolescence of many wonders. See the table (in README file).
-- The construction of a wonder no longer requires the presence of other buildings in the city. This way, most wonders appear as available in every city, and it is easier to keep track of them. However, some wonders still require another building in the city in order to get the bonus, and some of them require adjacent water ("Lighthouse", "Magellan's Expedition", "Hoover Dam") or specific resources available in the city ("Manhattan Project" and "Apollo Program").
+- The construction of a wonder no longer requires the presence of other buildings in the city. This way, most wonders appear as available in every city, and it is easier to keep track of them. However, some wonders still require another building in the city in order to get the bonus, and some of them require adjacent water ("Lighthouse", "Magellan's Expedition", "Hoover Dam") or a resource available in the city ("Manhattan Project").
 - Continental range: "J.S. Bach's Cathedral", "Great Wall" and "Sun Tzu's War Academy" affects only to cities of the same continent.
 - Global range: some minor effects, that may affect every player, added to "Cure For Cancer", "Internet", and "Women's Suffrage".
 * Every wonder produces as much culture per turn as its building cost/100.

--- a/3.0/civ2civ3_earth/README.ruleset_civ2civ3_earth
+++ b/3.0/civ2civ3_earth/README.ruleset_civ2civ3_earth
@@ -1,5 +1,5 @@
 ============================================================
-Civ2Civ3 Earth Ruleset for Freeciv v3.0 (Updated 05-2024)
+Civ2Civ3 Earth Ruleset for Freeciv v3.0 (Updated 12-2024)
 ============================================================
 
 "civ2civ3_earth" is a fork of the ruleset civ2civ3 (shipped with Freeciv since 2.5), from the same author. It includes new features, tries to improve balance, and is more suitable for playing on Earth maps, or similar scenarios. It includes its own tileset "amplio_earth", and a world map scenario, adapted to be played with these rules.
@@ -49,9 +49,9 @@ CORE CHANGES:
 
 - Allowed 1 trade route per city (2 after the discovery of The Corporation). Removed the one time revenues, and reduced the ongoing revenues. Trade routes with foreign cities receive 50% of the income, and only if the cities are allies (or on the same team).
 
-- Every unit (except Settlers, Migrants, and Fanatics, which cost population to build) pays some kind of upkeep cost. Some governments pay shields as upkeep, and others pay coins (similar to civ3), but not both.
+- Every unit pays some kind of upkeep cost (except Settlers, Migrants, and Fanatics, which cost population to build). Some governments pay shields as upkeep, and others pay coins (similar to civ3), but not both.
 
-- Most units also require upkeep in Food, except for Workers/Engineers, Diplomat/Spy, Caravan/Freight, Explorer/AWACS, and Cruise Missile/Nuclear.
+- Most units also require upkeep in Food (except for Workers/Engineers, Diplomat/Spy, Caravan/Freight, Explorer/AWACS, and Cruise Missile/Nuclear).
   A city can support for free as many units (with upkeep in Food) as its population size (min 4, max 20). Additional units cause waste of Food. If the city shrinks due to starvation, one of those extra units will be disbanded.
 
 - Units lose one veteran level when upgraded, and they do not gain veterancy from combat if the enemy is not killed.
@@ -101,7 +101,7 @@ CORE CHANGES:
 
 - Added a new barbarian nation that controls hostile animal units, randomly placed at the start of the game.
 
-- Added a new feature: Storms randomly appear and disappear on Deep Ocean or Glacier tiles, and they damage units ending the turn on an adjacent tile (or the same tile). Every unit entering the storm has its vision range reduced.
+- Added a new feature: Storms randomly appear (1%) and disappear (50%) on Deep Ocean or Glacier tiles, and they damage units ending the turn on an adjacent tile (or the same tile). Every unit entering the storm has its vision range reduced.
 
 
 OPTIONAL RULES:
@@ -234,7 +234,7 @@ Mountains -(36)---> Hills
 
 - Some units get additional veteran levels when certain resources are available in the city:
 
-  - Strategic resources (Horses, Ivory; Rubber, Aluminum, Uranium): +1 veteran level for certain units built in the city (or in any city linked by trade route).
+  - Strategic resources (Horses, Ivory; Rubber, Aluminum, Uranium): +1 veteran level for certain units built in the city (or in a city linked by trade route).
 
   - Key resources (Iron, Niter, Oil). For units that require Iron, Niter: -1 veteran level for each one of these resources that is not available in the city. For units that require Iron/Oil: -1 veteran level if none of these resources are available in the city.
 
@@ -274,7 +274,7 @@ Output per tile * -1(if>2) -1(if>2) -1(if>2) -        -        -        -       
 Celebration Bonus (no -1)  (no -1)  (no -1) (+1Trade) -       (+1Trade)(+1Trade)(+1Trade) -        -
 
 Unit Upkeep       Shield   Shield   Coin     Coin     Coin(x2) Shield   Coin(x2) Coin(x2) Shield   Coin(x2)
-Free Units        2        3        2        3        2        1        1        2        3        3
+Free Units        3        3        2        3        2        1        1        2        3        3
 War Unhappiness   0        0        0       -1       -1       -1       -2       -1       -1        0
 Martial Law      +1        0       +1       +1        0        0        0        0       +2       +2
 
@@ -289,18 +289,18 @@ Special         +NoUpkeep +Vision  +75%Lux  +50%Lux  +Tithes  +1Trade  +1Trade  
 
 Base Corruption   0%      30%      20%      10%      15%      25%       5%       0%      30%      15%
 Base Waste       30%       0%      10%      20%      15%       5%      25%      30%       0%      15%
-by Distance      +2%      +2%      +2%      +2%      +2%      +2%      +1%      +0%      +0%      +1%
+by Distance      +4%      +4%      +4%      +2%      +2%      +2%      +1%      +0%      +0%      +1%
 
-*: The output per tile penalty is negated by The Pyramids wonder, or when Railroad is researched by any player.
+*: The output per tile penalty is negated when Trade is researched by the player.
 
-- Added Tribal (available with Warrior Code), Fundamentalism (available with Theology), Federation (available with Economics) and Fascism (available with Military Tactics).
+- Added Tribalism (available with Warrior Code), Fundamentalism (available with Theology), Federation (available with Economics) and Fascism (available with Military Tactics).
 
-- "Celebration bonus": Republic and Democracy get the usual +1 Trade on every tile already producing Trade (same as Monarchy and Federation). Tribal and Despotism get the usual removal of the -1 penalty when any tile output is greater than 2.
+- "Celebration bonus": Republic and Democracy get the usual +1 Trade on every tile already producing Trade (same as Monarchy and Federation). Tribalism and Despotism get the usual removal of the -1 penalty when any tile output is greater than 2.
   The other governments get a small bonus of +1 Trade only in the city center tile (if already producing Trade).
 
-- "Base Corruption/Waste": Modern governments cause less Corruption in Trade, but more Waste in Production. The total % lost (Waste + Corruption) is equal for all governments. Corruption and waste by distance are fixed to +2% per tile for ancient governments, +1% for modern governments, and +0% for Federation and Communism.
+- "Base Corruption/Waste": Modern governments cause less Corruption in Trade, but more Waste in Production. The total % lost (Waste + Corruption) is equal for all governments. Corruption and waste by distance are fixed to +4% per tile for Despotism and Tribalism, +2% for other ancient governments, +1% for modern governments, and +0% for Federation and Communism.
 
-- "Unit Upkeep": Tribal, Republic and Communism use the standard unit upkeep in shields, while the other governments use upkeep in coins (x2 coins per unit for modern governments).
+- "Unit Upkeep": Tribalism, Republic and Communism use the standard unit upkeep in shields, while the other governments use upkeep in coins (x2 coins per unit for modern governments).
 
 - "Free Units": Means units free of shield/coin upkeep and also free of unhappiness due to military activity. By default 2 free units per city.
 
@@ -325,7 +325,7 @@ by Distance      +2%      +2%      +2%      +2%      +2%      +2%      +1%      
 
 - Under Communism, you do not pay upkeep for buildings that cost 1 or 2 coins (they can be up to 31 coins with all buildings, but rarely more than 25).
 
-- Tribal and Fascism increase the chance of units to obtain the next veteran level after a battle. Every unit in the case of Fascism; only ground units in the case of Tribal, but they also get increased vision radius.
+- Tribalism and Fascism increase the chance of units to obtain the next veteran level after a battle. Every unit in the case of Fascism; only ground units in the case of Tribalism, but they also get increased vision radius.
 
 - Spies and Diplomats built under Federation or Communism will start at the first veteran level.
 
@@ -334,19 +334,19 @@ by Distance      +2%      +2%      +2%      +2%      +2%      +2%      +1%      
 - Under Fascism or Fundamentalism, citizens of enemy nationality cause extra unhappiness in the city (1 unhappy face for each 2 enemy citizens).
   When you conquer a city, 25% of the foreign population is converted to your nationality. After that, foreign population is converted at a pace of one population every 20 turns or so.
 
-TIP: There is some hurry to get Monarchy or Republic (or to build Pyramids), in order to avoid the initial penalty to output per tile. However, the differences are more subtle, and every government could be useful in some situation or stage of the game:
-- Tribal increases the vision range and the chance of units becoming veteran after a combat; but it uses shields to pay unit upkeep (Despotism uses gold which can be an advantage in some cases).
+TIP: There is some hurry to get Monarchy or Republic (or to research Trade), in order to avoid the initial penalty to output per tile. However, the differences are more subtle, and every government could be useful in some situation or stage of the game:
+- Tribalism increases the vision range and the chance of units becoming veteran after a combat; but it uses shields to pay unit upkeep (Despotism uses gold which can be an advantage in some cases).
 - Monarchy avoids the penalty to output per tile. It gives low unit upkeep costs, but units outside your borders may cause unhappiness.
 - Republic gets a bonus to trade on irrigated land; but it has a senate, units no longer impose martial law, and units outside your borders may cause unhappiness more easily.
 - Fundamentalism gets a significant bonus to gold production, especially useful when terrain is not favorable; but it receives no revenue from city celebrations, and science production is low even with taxes on science at maximum.
 - Democracy gets the same trade bonus on irrigated land as Republic, and reduces the corruption and waste caused by distance from the palace; but it has a senate, and it doubles the unhappiness caused by units outside your borders.
-  It can be the best government once city celebrations generate revenue (when they produce more trade than required to celebrate), especially when cities are surrounded by plains, grasslands or swamps.
+  It can be the best government once city celebrations generate revenue (when they produce more trade than required to celebrate), especially when cities are surrounded by plains, with some forests/hills on rivers.
 - Federation eliminates the corruption and waste caused by distance from the palace, and its bonus to luxury production allows cities to celebrate more easily; but it does not get the trade bonus from irrigated land.
   It is a good alternative to Democracy for larger empires or more aggressive wars, especially when cities are surrounded by sea (less irrigated or mined land, but more trade).
 - Communism also eliminates the corruption and waste caused by distance from the palace, and reduces considerably the gold paid for upkeep of buildings; but it receives no revenue from city celebrations.
-  It is a good alternative to Federation for post-industrial large empires, especially when cities are surrounded by hills/mountains or jungles/forests (less trade, but more production).
-- Fascism gets a bonus to gold production on mined land, increases the chance of units becoming veteran, and is the only modern government whose units can't cause unhappiness; but it has standard upkeep of buildings, and corruption and waste caused by distance is not eliminated.
-  It is a good alternative for militaristic nations, especially when cities are surrounded by a mix of grasslands and hills/forests (with more mines, and food enough to work them).
+  It is a good alternative to Federation for post-industrial large empires, especially when cities are surrounded by hills, mountains or jungles (less trade, but more production).
+- Fascism gets a bonus to gold production on mined land, increases the chance of units becoming veteran, and it is the only modern government whose units can't cause unhappiness; but it has standard upkeep of buildings, and corruption and waste caused by distance is not eliminated.
+  It is a good alternative for militaristic nations, especially when cities are surrounded by a mix of grasslands and forests/hills (with more mines, and food enough to work them).
 
 
 TECHS:
@@ -379,7 +379,7 @@ Special effects:
 - Explosives allow new terrain improvements: Naval Mines to increase the defense of shallow oceans and to reduce the movement of adjacent naval units; Canals to connect oceans separated by no more than 2 land tiles.
 - Electricity: Allows irrigation without adjacent water, improves the effect of Amphitheatres, and grants you vision within your borders.
 - Refining: Allows to upgrade mines to oil wells (+2 production) on Desert, Tundra and Glacier.
-- Trade: Allows 1 trade route per city.
+- Trade: Allows 1 trade route per city. Cancels the output per tile penalty under Anarchy, Despotism and Tribalism.
 - The Corporation: Allows 2 trade routes per city.
 - Labor Union: Engineers are built with +1 veteran level.
 - Computers: All cities on the map are continuously visible despite fog-of-war (once Internet wonder have been built by any player).
@@ -452,23 +452,21 @@ Recycling Center  140   2      -50%/-25%
 DEFENSE:
 --------
 
-- Halved the terrain defense bonuses, now more similar to civ3 values:
-
-TERRAIN                   NEW      CIV2
-Forest/Jungle/Swamp       +25%     +50%
-Hills                     +50%     +100%
-Mountains                 +100%    +200%
-
-RIVER                     +25%     +50%
-
 VETERAN
 Regular                   +25%
-Veteran                   +50%     (=)
-Hardened                  +75%     (=)
-Elite                     +100%    (=)
+Veteran                   +50%
+Hardened                  +75%
+Elite                     +100%
 
-FORTIFIED                 +50%     (=)
+FORTIFIED                 +50%
 (only military ground units can fortify; inside cities, they are always considered fortified)
+
+TERRAIN
+Forest/Jungle/Swamp       +25%
+Hills                     +50%
+Mountains                 +100%
+
+RIVER                     +25%
 
 BASE             VS LAND  VS SEA   VS AIR   VS MISSILE
 Fort/Bombardment +50%     +50%      -        -
@@ -492,13 +490,15 @@ SDI Defense       -        -        -       +100%
 
 Great Wall       +50%      -        -        -
 
-OUTSIDE CITY
+OUTSIDE CITY (STACK)
 Stack of units   +25%     +25%     +25%     +25%
 
 
+- Halved the terrain defense bonuses, now more similar to civ3 values.
+
 - Every unit receives a +25% defense bonus when it is stacked outside of cities, as long as there is another unit on the same tile.
 
-- Naval units on Deep Ocean, or shallow Ocean adjacent to a Naval Mine, receive a +50% defense bonus against Sea units (not against Galleys or Submarines).
+- Naval units on Deep Ocean, or shallow Ocean adjacent to a Naval Mine, receive a +50% defense bonus against other naval units (except against Submarines).
 
 - Every city of any size receives an inherent +50% defense bonus against all ground and naval units (same as a fort).
 
@@ -510,16 +510,16 @@ Stack of units   +25%     +25%     +25%     +25%
 
 - Great Wall wonder gives an additional +50% defense bonus against ground units.
 
-Total Defense = (UNIT DEFENSE) * (100+TERRAIN)/100 * (100+RIVER)/100 * (100+CITY+BASE)/100 * (100+FORTIFIED)/100 * (100+VETERAN)/100
+Total Defense = (UNIT DEFENSE) * (100+TERRAIN)/100 * (100+RIVER)/100 * (100+CITY+BASE)/100 * (100+FORTIFIED)/100 * (100+VETERAN)/100 * (100+STACK)/100
 (Same as classic/civ2 rules).
 
-EXAMPLE: Riflemen fortified in a fortress, on mountains, with a river, will get a total defense of 30 against land attacks:
+EXAMPLE: Riflemen fortified in a fortress, on mountains, stacked with another unit, will get a total defense of 30 against land attacks:
 
          Riflemen: defense 4
          Fortified (+50%): 4 + 2 = 6
          In Fortress (+100%):      6 + 6 = 12
          On Mountains (+100%):             12 + 12 = 24
-         With River (+25%):                          24 + 6 = 30.
+         Stacked with other units (+25%):            24 + 6 = 30.
 
 EXAMPLE: Riflemen in a size 9 city, with walls, on hills, will get a total defense of 27 against land attacks:
 
@@ -608,7 +608,7 @@ The following unit changes are included in the table below:
 - Given Marine ability (named Raider) to Legion, Musketeer, and Rifleman. This way, one-tile islands can be assaulted early in game. Yet, the Marine unit is still the best offensive/defensive infantry.
 - Caravel changed from (2/1) to (1/2), in order to encourage peaceful exploration of the seas in the age of discovery. Galleon attack increased to 2 and no longer non-military.
 - Removed transport capability from Frigates, to force the use of Galleons. Reduced attack of Frigate and defense of Ironclad to 3 (was 4).
-- Battleship's hit points reduced to 30 (was 40), Ironclad and Submarine to 20 (was 30). Submarine defense increased to 4, and doubled against air attacks. Doubled the defense of Destroyers against Submarines. Now there is a Rock-paper-scissors relationship between Submarine-Destroyer-Cruiser.
+- Battleship's hit points reduced to 30 (was 40), Ironclad and Submarine to 20 (was 30). Submarine defense increased to 4, and doubled against air attacks. Doubled the defense of Destroyers against Submarines.
 - Naval units with transport capability don't cause unhappiness due to military activity, but their military cargo do cause unhappiness when deployed outside national borders, as usual.
 - All air units can cause unhappiness when they end the turn outside national borders. Nuclear missiles and air bombers cause unhappiness all the time, even inside national borders.
 - Air bombers and Helicopters have more hit points, but halved attack to make it harder to bombard enemies successfully.
@@ -691,11 +691,11 @@ In full base              *(+24%)    34% Fortress   Deep Ocean)    34% Airbase
 RESTING INSIDE CITY  (HP REGEN %)    LAND           SEA            AIR
 Without improvement       #(+34%)    44%            44%            34%
 With improvement          *(+50%)    60% Barracks   60% Port       50% Airport
-(non mechanized)                    +15% Hospital
+(non wheeled)                       +15% Hospital
 
 EVERY TURN
 On plains, grassland or shallow ocean, with knowledge of:
-  Medicine (non mechanized units)                   +2 HP
+  Medicine (non wheeled ground units)               +2 HP
   Physics (wheeled or naval units)                  +2 HP
 
 On any oceanic or glacier tile adjacent to a Storm: -4 HP
@@ -726,7 +726,7 @@ FULL LIST OF WONDERS
 "Name", Cost, Requirements, Obsolescence, Effect.
 
 -=- "Pyramids" 200. Obsolete by Railroad (that increases even more the production):
-+1 Production per worked tile in the city (already producing shields). Disables the output per tile penalty under Despotism/Tribal governments.
++1 Production per worked tile in the city (already producing shields).
 -=- "Colossus" 200. Obsolete by Automobile (Super Highways):
 +1 Trade per worked tile in the city (already producing Trade).
 -=- "Copernicus' Observatory" 300. Obsolete by Radio:
@@ -793,7 +793,7 @@ Gives to all your Hydro Plants the same effect as Solar Plants (-25% pollution c
 
 --- (#)"Manhattan Project" 600. Requires Uranium:
 # Enables Nuclear units for every nation.
---- (#)"Apollo Program" 600. Requires Aluminum:
+--- (#)"Apollo Program" 600:
 Makes the entire map (but not the units) permanently visible for the owner.
 # Enables space race for every nation.
 -=- (#)"United Nations" 600:

--- a/3.0/civ2civ3_earth/buildings.ruleset
+++ b/3.0/civ2civ3_earth/buildings.ruleset
@@ -1401,7 +1401,6 @@ genus		= "GreatWonder"
 reqs	=
     { "type", "name", "range"
       "Tech", "Space Flight", "Player"
-      "Extra", "Aluminum", "Traderoute"
     }
 graphic	= "b.apollo_program"
 graphic_alt	= "-"
@@ -1956,10 +1955,7 @@ sound		= "w_pyramids"
 sound_alt	= "w_generic"
 helptext	= _("\
 Each tile around the city where this wonder is built that is already \
-generating some shield output produces one extra shield resource. \
-Under Despotism or Tribal governments, the Pyramids cancel the penalty \
-to worked tiles with output greater than 2 (for all kinds of output), \
-as if all your cities were always celebrating.\
+generating some shield output produces one extra shield resource.\
 ")
 
 [building_shakespeares_theatre]

--- a/3.0/civ2civ3_earth/effects.ruleset
+++ b/3.0/civ2civ3_earth/effects.ruleset
@@ -403,7 +403,8 @@ value   = 50
 reqs    =
     { "type", "name", "range", "present"
       "Terrain", "Deep Ocean", "Local", TRUE
-      "UnitClass", "Sea", "Local", TRUE
+      "UnitClassFlag", "Naval", "Local", TRUE
+      "UnitClass", "Sub", "Local", FALSE
     }
 
 ; Defense bonus against sea units on ocean adjacent to naval mine
@@ -415,7 +416,8 @@ reqs    =
       "Extra", "Naval Mine", "Adjacent", TRUE
       "TerrainClass", "Oceanic", "Local", TRUE
       "Terrain", "Deep Ocean", "Local", FALSE
-      "UnitClass", "Sea", "Local", TRUE
+      "UnitClassFlag", "Naval", "Local", TRUE
+      "UnitClass", "Sub", "Local", FALSE
     }
 
 ; Movement penalty adjacent to naval mines
@@ -597,6 +599,7 @@ reqs    =
     }
 
 ; City: against every land and sea
+; City defense is equal to a Fort
 [effect_city_defense_0]
 type    = "Defend_Bonus"
 value   = 50
@@ -607,6 +610,7 @@ reqs    =
     }
 
 ; City (size > 8): against every land and sea
+; 50 + 50 = 100
 [effect_city_defense_1]
 type    = "Defend_Bonus"
 value   = 50
@@ -971,9 +975,49 @@ reqs    =
       "NationGroup", "Barbarian", "Player", FALSE
     }
 
+; Trade waste -4% each tile
+[effect_corruption_distance]
+type    = "Output_Waste_By_Distance"
+value   = 400
+reqs    =
+    { "type", "name", "range", "present"
+      "OutputType", "Trade", "Local", TRUE
+;      "Gov", "Anarchy", "Player", FALSE
+;      "Gov", "Tribal", "Player", FALSE
+;      "Gov", "Despotism", "Player", FALSE
+      "Gov", "Monarchy", "Player", FALSE
+      "Gov", "Fascism", "Player", FALSE
+      "Gov", "Communism", "Player", FALSE
+      "Gov", "Fundamentalism", "Player", FALSE
+      "Gov", "Federation", "Player", FALSE
+      "Gov", "Republic", "Player", FALSE
+      "Gov", "Democracy", "Player", FALSE
+      "NationGroup", "Barbarian", "Player", FALSE
+    }
+
+; Trade waste -2% each tile
+[effect_corruption_distance_ancient]
+type    = "Output_Waste_By_Distance"
+value   = 200
+reqs    =
+    { "type", "name", "range", "present"
+      "OutputType", "Trade", "Local", TRUE
+      "Gov", "Anarchy", "Player", FALSE
+      "Gov", "Tribal", "Player", FALSE
+      "Gov", "Despotism", "Player", FALSE
+;      "Gov", "Monarchy", "Player", FALSE
+      "Gov", "Fascism", "Player", FALSE
+      "Gov", "Communism", "Player", FALSE
+;      "Gov", "Fundamentalism", "Player", FALSE
+      "Gov", "Federation", "Player", FALSE
+;      "Gov", "Republic", "Player", FALSE
+      "Gov", "Democracy", "Player", FALSE
+      "NationGroup", "Barbarian", "Player", FALSE
+    }
+
 ; Trade waste -1% each tile
 ; (Federation and Communism 0%)
-[effect_corruption_distance]
+[effect_corruption_distance_modern]
 type    = "Output_Waste_By_Distance"
 value   = 100
 reqs    =
@@ -989,26 +1033,6 @@ reqs    =
       "Gov", "Federation", "Player", FALSE
       "Gov", "Republic", "Player", FALSE
 ;      "Gov", "Democracy", "Player", FALSE
-      "NationGroup", "Barbarian", "Player", FALSE
-    }
-
-; Trade waste -2% each tile
-[effect_corruption_distance_ancient]
-type    = "Output_Waste_By_Distance"
-value   = 200
-reqs    =
-    { "type", "name", "range", "present"
-      "OutputType", "Trade", "Local", TRUE
-;      "Gov", "Anarchy", "Player", FALSE
-;      "Gov", "Tribal", "Player", FALSE
-;      "Gov", "Despotism", "Player", FALSE
-;      "Gov", "Monarchy", "Player", FALSE
-      "Gov", "Fascism", "Player", FALSE
-      "Gov", "Communism", "Player", FALSE
-;      "Gov", "Fundamentalism", "Player", FALSE
-      "Gov", "Federation", "Player", FALSE
-;      "Gov", "Republic", "Player", FALSE
-      "Gov", "Democracy", "Player", FALSE
       "NationGroup", "Barbarian", "Player", FALSE
     }
 
@@ -1104,8 +1128,48 @@ reqs    =
       "OutputType", "Trade", "Local", FALSE
     }
 
-; Production waste -1% shields each tile
+; Production waste -4% shields each tile
 [effect_waste_distance]
+type    = "Output_Waste_By_Distance"
+value   = 400
+reqs    =
+    { "type", "name", "range", "present"
+      "OutputType", "Shield", "Local", TRUE
+;      "Gov", "Anarchy", "Player", FALSE
+;      "Gov", "Tribal", "Player", FALSE
+;      "Gov", "Despotism", "Player", FALSE
+      "Gov", "Monarchy", "Player", FALSE
+      "Gov", "Fascism", "Player", FALSE
+      "Gov", "Communism", "Player", FALSE
+      "Gov", "Fundamentalism", "Player", FALSE
+      "Gov", "Federation", "Player", FALSE
+      "Gov", "Republic", "Player", FALSE
+      "Gov", "Democracy", "Player", FALSE
+      "NationGroup", "Barbarian", "Player", FALSE
+    }
+
+; Production waste -2% shields each tile
+[effect_waste_distance_ancient]
+type    = "Output_Waste_By_Distance"
+value   = 200
+reqs    =
+    { "type", "name", "range", "present"
+      "OutputType", "Shield", "Local", TRUE
+      "Gov", "Anarchy", "Player", FALSE
+      "Gov", "Tribal", "Player", FALSE
+      "Gov", "Despotism", "Player", FALSE
+;      "Gov", "Monarchy", "Player", FALSE
+      "Gov", "Fascism", "Player", FALSE
+      "Gov", "Communism", "Player", FALSE
+;      "Gov", "Fundamentalism", "Player", FALSE
+      "Gov", "Federation", "Player", FALSE
+;      "Gov", "Republic", "Player", FALSE
+      "Gov", "Democracy", "Player", FALSE
+      "NationGroup", "Barbarian", "Player", FALSE
+    }
+
+; Production waste -1% shields each tile
+[effect_waste_distance_modern]
 type    = "Output_Waste_By_Distance"
 value   = 100
 reqs    =
@@ -1121,26 +1185,6 @@ reqs    =
       "Gov", "Federation", "Player", FALSE
       "Gov", "Republic", "Player", FALSE
 ;      "Gov", "Democracy", "Player", FALSE
-      "NationGroup", "Barbarian", "Player", FALSE
-    }
-
-; Production waste -2% shields each tile
-[effect_waste_distance_ancient]
-type    = "Output_Waste_By_Distance"
-value   = 200
-reqs    =
-    { "type", "name", "range", "present"
-      "OutputType", "Shield", "Local", TRUE
-;      "Gov", "Anarchy", "Player", FALSE
-;      "Gov", "Tribal", "Player", FALSE
-;      "Gov", "Despotism", "Player", FALSE
-;      "Gov", "Monarchy", "Player", FALSE
-      "Gov", "Fascism", "Player", FALSE
-      "Gov", "Communism", "Player", FALSE
-;      "Gov", "Fundamentalism", "Player", FALSE
-      "Gov", "Federation", "Player", FALSE
-;      "Gov", "Republic", "Player", FALSE
-      "Gov", "Democracy", "Player", FALSE
       "NationGroup", "Barbarian", "Player", FALSE
     }
 
@@ -1406,7 +1450,7 @@ reqs    =
 
 [effect_upkeep_free_units_anarchy]
 type    = "Unit_Upkeep_Free_Per_City"
-value   = 2
+value   = 3
 reqs    =
     { "type", "name", "range", "quiet"
       "Gov", "Anarchy", "Player", TRUE
@@ -2089,15 +2133,13 @@ reqs    =
       "Gov", "Democracy", "Player", FALSE
     }
 
-; Railroad because makes Pyramids obsolete
 [effect_gov_tile_penalty_anarchy]
 type    = "Output_Penalty_Tile"
 value   = 2
 reqs    =
     { "type", "name", "range", "present", "quiet"
-      "Gov", "Anarchy", "Player", TRUE, TRUE
-      "Building", "Pyramids", "Player", FALSE, FALSE
-      "Tech", "Railroad", "World", FALSE, FALSE
+      "Gov", "Anarchy", "Player", TRUE, FALSE
+      "Tech", "Trade", "Player", FALSE, FALSE
       "OutputType", "Gold", "Local", FALSE, TRUE
       "OutputType", "Luxury", "Local", FALSE, TRUE
       "OutputType", "Science", "Local", FALSE, TRUE
@@ -2108,9 +2150,8 @@ type    = "Output_Penalty_Tile"
 value   = 2
 reqs    =
     { "type", "name", "range", "present", "quiet"
-      "Gov", "Tribal", "Player", TRUE, TRUE
-      "Building", "Pyramids", "Player", FALSE, FALSE
-      "Tech", "Railroad", "World", FALSE, FALSE
+      "Gov", "Tribal", "Player", TRUE, FALSE
+      "Tech", "Trade", "Player", FALSE, FALSE
       "OutputType", "Gold", "Local", FALSE, TRUE
       "OutputType", "Luxury", "Local", FALSE, TRUE
       "OutputType", "Science", "Local", FALSE, TRUE
@@ -2121,9 +2162,8 @@ type    = "Output_Penalty_Tile"
 value   = 2
 reqs    =
     { "type", "name", "range", "present", "quiet"
-      "Gov", "Despotism", "Player", TRUE, TRUE
-      "Building", "Pyramids", "Player", FALSE, FALSE
-      "Tech", "Railroad", "World", FALSE, FALSE
+      "Gov", "Despotism", "Player", TRUE, FALSE
+      "Tech", "Trade", "Player", FALSE, FALSE
       "OutputType", "Gold", "Local", FALSE, TRUE
       "OutputType", "Luxury", "Local", FALSE, TRUE
       "OutputType", "Science", "Local", FALSE, TRUE
@@ -2207,26 +2247,6 @@ reqs    =
 ;      "Gov", "Federation", "Player", FALSE
 ;      "Gov", "Republic", "Player", FALSE
 ;      "Gov", "Democracy", "Player", FALSE
-    }
-
-; Celebration: only city center tile
-[effect_gov_tile_bonus_celebrate_center]
-type    = "Output_Inc_Tile_Celebrate"
-value   = 1
-reqs    =
-    { "type", "name", "range", "present"
-      "OutputType", "Trade", "Local", TRUE
-      "CityTile", "Center", "Local", TRUE
-      "Gov", "Anarchy", "Player", FALSE
-      "Gov", "Tribal", "Player", FALSE
-      "Gov", "Despotism", "Player", FALSE
-      "Gov", "Monarchy", "Player", FALSE
-;      "Gov", "Fascism", "Player", FALSE
-;      "Gov", "Communism", "Player", FALSE
-;      "Gov", "Fundamentalism", "Player", FALSE
-      "Gov", "Federation", "Player", FALSE
-      "Gov", "Republic", "Player", FALSE
-      "Gov", "Democracy", "Player", FALSE
     }
 
 [effect_vision_tribal]

--- a/3.0/civ2civ3_earth/game.ruleset
+++ b/3.0/civ2civ3_earth/game.ruleset
@@ -26,7 +26,7 @@ description_file = "civ2civ3_earth/README.ruleset_civ2civ3_earth"
 name = _("Civ2Civ3 Earth ruleset")
 
 ; There`s no separate versioning in rulesets part of main freeciv distribution
-version = "3.0_2024_05"
+version = "3.0_2024_05b"
 
 ; Summary of the ruleset
 summary = _("\

--- a/3.0/civ2civ3_earth/governments.ruleset
+++ b/3.0/civ2civ3_earth/governments.ruleset
@@ -79,8 +79,8 @@ Anarchy is simply the absence of any recognizable government.\
 _("\
 * Buildings and technologies do not require any upkeep.\n\
 * Each worked tile that gives more than 2 Food, Production, or Trade will\
- suffer a -1 penalty, unless the city working it is celebrating.\
- (Cities below size 3 will not celebrate.)\n\
+ suffer a -1 penalty, unless the player has researched Trade technology,\
+ or the city is celebrating. (Cities below size 3 will not celebrate.)\n\
 * All citizens are unhappy by default.\n\
 * Each city can support up to 2 units for free; further units each cost\
  1 shield per turn.\n\
@@ -98,7 +98,8 @@ _("\
 ;------------------------------------------------------------------------
 [government_tribal]
 
-name        = _("Tribal")
+name        = _("Tribalism")
+rule_name   = _("Tribal")
 reqs = { "type", "name", "range"
          "tech", "Warrior Code", "Player"
        }
@@ -110,10 +111,10 @@ ruler_male_title = _("Warlord %s")
 ruler_female_title = _("Warlady %s")
 
 helptext = _("\
-Under a Tribal government, you are part ruler of your people. Your\
- control over your citizens is maintained largely by spiritual counsel.\
+Under Tribalism, you are part ruler of your people. Your control over\
+ your citizens is maintained largely by spiritual counsel.\
 "), _("\
-Compared to Despotism, a Tribal economy is more shield-oriented. Its\
+Compared to Despotism, a tribal economy is more shield-oriented. Its\
  bonuses to veterancy and vision range can be an advantage in wartime,\
  but it lacks the martial law of other early governments.\
 "),
@@ -122,8 +123,8 @@ _("\
 * Increases by half the chance of land units to obtain the next veteran\
  level after a battle, and also increases their vision range.\n\
 * Each worked tile that gives more than 2 Food, Production, or Trade will\
- suffer a -1 penalty, unless the city working it is celebrating.\
- (Cities below size 3 will not celebrate.)\n\
+ suffer a -1 penalty, unless the player has researched Trade technology,\
+ or the city is celebrating. (Cities below size 3 will not celebrate.)\n\
 * The first 5 citizens of each city are content by default.\
  The 6th citizen will be the first unhappy one.\n\
 * Each city can support up to 3 units for free; further units each cost\
@@ -133,7 +134,7 @@ _("\
 * Base corruption is 30% (the highest under any government). This\
  increases by 2% for each tile of distance from the capital.\n\
 * There is no base level of production waste, but it increases\
- by 2% for each tile of distance from the capital.\n\
+ by 2% for each tile of distance from the capital.\
 ")
 
 ;------------------------------------------------------------------------
@@ -159,8 +160,8 @@ _("\
 * Your centers of government (cities with Palace and Ecclesiastical\
  Palace) get a +75% bonus to luxury production.\n\
 * Each worked tile that gives more than 2 Food, Production, or Trade will\
- suffer a -1 penalty, unless the city working it is celebrating.\
- (Cities below size 3 will not celebrate.)\n\
+ suffer a -1 penalty, unless the player has researched Trade technology,\
+ or the city is celebrating. (Cities below size 3 will not celebrate.)\n\
 * The first 4 citizens of each city are content by default.\
  The 5th citizen will be the first unhappy one.\n\
 * Each city can support up to 2 units for free; further units each cost\
@@ -238,8 +239,8 @@ Communism eliminates the corruption and waste caused by distance from\
  buildings; but it does not get the trade bonus from irrigated land\
  or city celebrations.\
 "), _("\
-It is a good alternative to Federation for large empires, especially\
- when cities are surrounded by hills, mountains, jungles or forests\
+It is a good alternative to Federation for post-industrial large empires,\
+ especially when cities are surrounded by hills, mountains or jungles\
  (less trade, but more production).\
 "),
 ; /* xgettext:no-c-format */
@@ -287,8 +288,8 @@ Improvements that normally convert unhappy citizens to content\
  of people they would convert.\
 "), _("\
 Fundamentalism gets a significant bonus to gold production, especially\
- useful when terrain is not favorable for trade; but city celebrations\
- give no revenues, and science production is low even with taxes on\
+ useful when terrain is not favorable; but it receives no revenue from\
+ city celebrations, and science production is low even with taxes on\
  science at maximum.\
 "),
 ; /* xgettext:no-c-format */
@@ -329,7 +330,7 @@ Federation eliminates the corruption and waste caused by distance from\
 "), _("\
 It is a good alternative to Democracy for larger empires or more\
  aggressive wars, especially when cities are surrounded by sea (less\
- land, but more trade).\
+ irrigated or mined land, but more trade).\
 "),
 ; /* xgettext:no-c-format */
 _("\
@@ -343,7 +344,7 @@ _("\
  each further unit causes 1 unhappy citizen.\n\
 * There is no corruption.\n\
 * Base production waste is 30%, but is not affected by distance to the\
- capital.\n\
+ capital.\
 ")
 
 ;------------------------------------------------------------------------
@@ -385,7 +386,7 @@ irrigation.\n\
 * Base corruption is 25%. This increases by 2% for each tile of distance\
  from the capital.\n\
 * Base production waste is 5%. This increases by 2% for each tile of\
- distance from the capital.\
+ distance from the capital.\n\
 * Has a senate that may prevent declaration of war.\
 ")
 
@@ -413,8 +414,9 @@ Democracy gets the same trade bonus on irrigated land as Republic,\
  palace; but it has a senate, and it doubles the unhappiness caused\
  by units outside your borders.\
 "), _("\
-It is the best government once city celebrations give revenues (when\
- they produce more trade than the required to celebrate).\
+It can be the best government once city celebrations generate revenue\
+ (when they produce more trade than the required to celebrate),\
+ especially when cities are surrounded by plains and rivers.\
 "),
 ; /* xgettext:no-c-format */
 _("\
@@ -452,13 +454,14 @@ Fascism seeks to solve economic, political, and social problems by\
  achieving a national rebirth, exalting the nation or race above all\
  else, and promoting cults of unity, strength, and purity.\
 "), _("\
-Fascism avoids the upkeep costs of many buildings like Communism,\
- increases the chance of units becoming veteran, and it is the only\
- modern government whose units can't cause unhappiness; but corruption\
- and waste caused by distance is not eliminated.\
+Fascism gets a bonus to gold production on mined land, increases the\
+ chance of units becoming veteran, and it is the only modern government\
+ whose units can't cause unhappiness; but it has standard upkeep of\
+ buildings, and corruption and waste caused by distance is not eliminated.\
 "), _("\
-It is a good alternative for militaristic nations, especially when city\
- celebrations are not worth the cost.\
+It is a good alternative for militaristic nations, especially when\
+ cities are surrounded by a mix of grasslands and hills or forests\
+ (more mines, and food enough to work them).\
 "),
 ; /* xgettext:no-c-format */
 _("\
@@ -475,7 +478,7 @@ _("\
 * Base corruption is 15%. This increases by 1% for each tile of distance\
  from the capital.\n\
 * Base production waste is 15%. This increases by 1% for each tile of\
- distance from the capital.\n\
+ distance from the capital.\
 ")
 
 ; /* <-- avoid gettext warnings

--- a/3.0/civ2civ3_earth/techs.ruleset
+++ b/3.0/civ2civ3_earth/techs.ruleset
@@ -517,7 +517,6 @@ helptext = _("\
 Aluminum resources produce 2 extra shields in the tile where they are \
 located.\
 "), _("\
-Aluminum is required in a city to build the wonder Apollo Program. \
 Cities with available Aluminum build Carrier, AEGIS Cruiser, Cruise \
 Missile, Fighter and Bomber units with one extra veteran level.\
 ")
@@ -826,10 +825,6 @@ graphic_alt = "-"
 helptext = _("\
 Allows Settlers, Migrants, Workers and Engineers to upgrade roads to \
 railroads.\
-"), _("\
-For Despotism or Tribal governments, cancels the penalty to worked \
-tiles with output greater than 2 (as if all your cities were always \
-celebrating).\
 ")
 ;cost     = 350
 
@@ -1043,6 +1038,9 @@ flags    = ""
 graphic     = "a.trade"
 graphic_alt = "-"
 helptext = _("\
+Cancels the penalty to output per tile caused by Anarchy, Despotism \
+or Tribalism governments.\
+"), _("\
 Allows establishing up to 1 trade route from each city.\
 "), _("\
 When 2 cities are linked by a trade route, any special resource present \

--- a/3.0/civ2civ3_earth/terrain.ruleset
+++ b/3.0/civ2civ3_earth/terrain.ruleset
@@ -1258,7 +1258,7 @@ rmact_gfx_alt  = "-"
 reqs           =
     { "type", "name", "range", "present", "quiet"
       "TerrainFlag", "Wood", "Local", FALSE, TRUE
-      "TerrainClass", "Oceanic", "Local", FALSE, TRUE
+      "TerrainClass", "Land", "Local", TRUE, FALSE
       "UnitClassFlag", "Naval", "Local", FALSE, TRUE
     }
 rmreqs         =
@@ -1293,7 +1293,7 @@ rmact_gfx      = "None"
 rmact_gfx_alt  = "-"
 reqs           =
     { "type", "name", "range", "present", "quiet"
-      "TerrainFlag", "Wood", "Local", TRUE, TRUE
+      "TerrainFlag", "Wood", "Local", TRUE, FALSE
       "UnitClassFlag", "Naval", "Local", FALSE, TRUE
     }
 rmreqs         =
@@ -1324,7 +1324,7 @@ rmact_gfx_alt  = "-"
 reqs           =
     { "type", "name", "range", "present", "quiet"
       "Tech", "Refining", "Player", TRUE, FALSE
-      "TerrainFlag", "Oil", "Local", TRUE, TRUE
+      "TerrainFlag", "Oil", "Local", TRUE, FALSE
       "Extra", "Mine", "Local", TRUE, FALSE
       "UnitClassFlag", "Naval", "Local", FALSE, TRUE
     }
@@ -1479,10 +1479,10 @@ rmact_gfx_alt  = "-"
 ; Note, there are extra restrictions on where farmland can be built
 ; through Irrig_Possible effects
 reqs           =
-    { "type", "name", "range", "present"
-      "Tech", "Refrigeration", "Player", TRUE
-      "Extra", "Irrigation", "Local", TRUE
-      "CityTile", "Center", "Local", FALSE
+    { "type", "name", "range", "present", "quiet"
+      "Tech", "Refrigeration", "Player", TRUE, FALSE
+      "Extra", "Irrigation", "Local", TRUE, FALSE
+      "CityTile", "Center", "Local", FALSE, TRUE
     }
 rmreqs         =
     { "type", "name", "range", "present"
@@ -1648,8 +1648,9 @@ reqs           =
       "UnitFlag", "Fortress", "Local", TRUE, FALSE
       "UnitFlag", "Settlers", "Local", TRUE, FALSE
       "UnitState", "OnDomesticTile", "Local", TRUE, FALSE
-      "TerrainFlag", "NoCities", "Local", FALSE, FALSE
-      "CityTile", "Center", "Adjacent", FALSE, FALSE
+      "Terrain", "Glacier", "Local", FALSE, FALSE
+      "Terrain", "Mountains", "Local", FALSE, FALSE
+      "CityTile", "Center", "Adjacent", FALSE, TRUE
       "Extra", "Castle", "Adjacent", FALSE, FALSE
     }
 rmreqs         =
@@ -2051,8 +2052,8 @@ reqs           =
       "Tech", "Explosives", "Player", TRUE, FALSE
       "TerrainClass", "Land", "Local", TRUE, FALSE
       "Terrain", "Glacier", "Local", FALSE, FALSE
-      "Terrain", "Hills", "Local", FALSE, FALSE
       "Terrain", "Mountains", "Local", FALSE, FALSE
+      "Terrain", "Hills", "Local", FALSE, FALSE
       "TerrainClass", "Oceanic", "CAdjacent", TRUE, FALSE
       "UnitFlag", "Settlers", "Local", TRUE, FALSE
       "UnitState", "OnDomesticTile", "Local", TRUE, FALSE
@@ -2178,11 +2179,11 @@ rmact_gfx_alt  = "-"
 ;visibility_req = "Industrialization"
 buildable      = FALSE
 conflicts      = "Niter", "Rubber", "Uranium"
-flags          = "TerrChangeRemoves"
+;flags          = "TerrChangeRemoves"
 helptext       = _("\
-Strategic resource, required in a city to build the wonder Apollo \
-Program. Cities with available aluminum build Carrier, AEGIS Cruiser, \
-Cruise Missile, Fighter and Bomber units with one extra veteran level.\
+Strategic resource. Cities with available aluminum build Carrier, \
+AEGIS Cruiser, Cruise Missile, Fighter and Bomber units with one extra \
+veteran level.\
 "), _("\
 With the discovery of Industrialization, aluminum produces 2 extra shields \
 in the tile (hills or tundra).\
@@ -2203,7 +2204,7 @@ rmact_gfx_alt  = "-"
 ;visibility_req = "Gunpowder"
 buildable      = FALSE
 conflicts      = "Aluminum", "Rubber", "Uranium"
-flags          = "TerrChangeRemoves"
+;flags          = "TerrChangeRemoves"
 helptext       = _("\
 Strategic resource. Cities without available niter build gunpowder \
 based units with one less veteran level: Musketeers, Riflemen, Alpine \
@@ -2229,7 +2230,7 @@ rmact_gfx_alt  = "-"
 ;visibility_req = "Chemistry"
 buildable      = FALSE
 conflicts      = "Aluminum", "Niter", "Uranium"
-flags          = "TerrChangeRemoves"
+;flags          = "TerrChangeRemoves"
 helptext       = _("\
 Strategic resource. Cities with available rubber build Marines, \
 Paratroopers, Helicopter, Mech. Inf. and Howitzer units with one extra \
@@ -2254,7 +2255,7 @@ rmact_gfx_alt  = "-"
 ;visibility_req = "Atomic Theory"
 buildable      = FALSE
 conflicts      = "Aluminum", "Niter", "Rubber"
-flags          = "TerrChangeRemoves"
+;flags          = "TerrChangeRemoves"
 helptext       = _("\
 Strategic resource, required in a city to build a Nuclear Plant or \
 the wonder Manhattan Project. Cities with available uranium build \

--- a/3.0/civ2civ3_earth/units.ruleset
+++ b/3.0/civ2civ3_earth/units.ruleset
@@ -1286,9 +1286,8 @@ Chariots are horse-pulled war wagons, stronger but more expensive \
 than horsemen.\
 "), _("\
 As with other units in this class: they cannot take advantage of \
-terrain to defend themselves; they can bombard from coastal land to \
-sea; and they can cause loss of population when attacking a city \
-without City Walls.\
+terrain to defend themselves; and they can cause loss of population \
+when attacking a city without City Walls.\
 ")
 
 [unit_elephants]
@@ -1737,6 +1736,10 @@ turns, it can automatically attack or bombard an incoming enemy.\
 _("\
 As with other aircraft: they lose 10% of their hit points for every \
 turn not spent in a city, airstrip, or airbase, or on a Carrier.\
+"), _("\
+TIP: When a fighter ends its turn in the open, you can use the Goto \
+action to automatically move it to a city or airbase, in order to prevent \
+it from auto-attacking and running out of fuel.\
 ")
 
 [unit_bomber]
@@ -2302,7 +2305,7 @@ bonuses       =
    }
 flags         = "Partial_Invis", "BadCityDefender", "Submarine", "Bombarder",
                 "HPFullSea", "HP20", "HasNoZOC", "Iron_Oil", "Uranium"
-roles         = "Hunter", "DefendOk", "DefendOkStartUnit"
+roles         = "Hunter", "DefendOk"
 helptext      = _("\
 Traveling under the surface of the ocean, Submarines have a very high \
 strategic value, but a weak defense if caught off guard.\

--- a/3.1/amplio_earth.tilespec
+++ b/3.1/amplio_earth.tilespec
@@ -9,7 +9,7 @@ name = "amplio_earth"
 priority = 30
 
 ; There`s no separate versioning in tilesets part of main freeciv distribution
-version = "3.1_2024_05"
+version = "3.1_2024_05b"
 
 ; Summary and full description of the tileset.
 summary = _("Large isometric tileset based on Amplio.")

--- a/3.1/amplio_earth/README.tileset_civ2civ3_earth
+++ b/3.1/amplio_earth/README.tileset_civ2civ3_earth
@@ -3,7 +3,7 @@ Amplio Earth Tileset for Freeciv v3.1
 =====================================
 
 Tileset based on Amplio2 (by GriffonSpade), but with small flags, small resources, and colors more similar to Amplio (and to minimap).
-Compiled by Bardo and released under GPLv2 license (see each .spec file for detailed credits).
+Edited by Bardo and released under GPLv2 license (see each .spec file for detailed credits).
 
 Modded from Amplio2:
 - mountains, with colors from Amplio mountains.
@@ -53,4 +53,5 @@ Modded from Hexemplio:
 Known issues:
 - Ocean file needs to be adjusted for the lack of E-W blend between land, ocean, and deep ocean.
 I made some minor adjustments, but it is still too noticeable.
+- I suggest to play with the Map Grid enabled (in the View menu).
 

--- a/3.1/ampliohex_earth.tilespec
+++ b/3.1/ampliohex_earth.tilespec
@@ -9,7 +9,7 @@ name = "ampliohex_earth"
 priority = 30
 
 ; There`s no separate versioning in tilesets part of main freeciv distribution
-version = "3.1_2024_05"
+version = "3.1_2024_05b"
 
 ; Summary and full description of the tileset.
 summary = _("Large isometric tileset based on Amplio.")

--- a/3.1/civ2civ3_earth-3.1.mpdl
+++ b/3.1/civ2civ3_earth-3.1.mpdl
@@ -3,7 +3,7 @@ options = "+Freeciv-3.1-mpdl"
 baseURL = "./"
 name    = "Civ2civ3_Earth"
 type    = "Modpack"
-version = "2024_05"
+version = "2024_05b"
 
 [files]
 list =

--- a/3.1/civ2civ3_earth/NEWS.ruleset_civ2civ3_earth
+++ b/3.1/civ2civ3_earth/NEWS.ruleset_civ2civ3_earth
@@ -8,10 +8,12 @@ Known issues:
 * If the ruleset is played with a version of Freeciv prior to 3.1.2, the AI will not move the infantry units. This happens because the "Settler" flag is mandatory to be able to build fortresses in 3.1, and the AI manages these units as settlers until it is fixed in 3.1.2.
 - The server settings suggested by the ruleset are no longer loaded by default. Due to changes in Freeciv 3.0, now user settings (from freeciv-client-rc) and ruleset settings (from game.ruleset) are mixed in a kind of unpredictable way. I suggest using a clean version of freeciv-client-rc-3.x before starting a new game.
 * This modpack includes 2 custom tilesets, one for square and one for hexagonal topology, but they are no longer loaded by default. The player has to select them manually from the client local options -> Graphics -> Tileset (or by editing the values starting with "default_tileset_" in the file freeciv-client-rc).
+* When playing with hexagonal topology, I suggest enabling the map grid (in the View menu) and increasing the minimum distance between cities (citymindist setting) to 4 in order to force the AI to build better cities.
 
 Fixed bugs:
 - Strategic resources no longer appear on the same tile as other special resources.
 * The AI seems to get stuck around tiles that cause damage. These effects are now disabled for the AI (hit point loss of air units in the open, galleys in deep ocean, and units near storms). Naval mines have also been changed to reduce movement points instead of hit points.
+* Fixed an error in the script that checks the new victory condition of SETI Program.
 
 Core:
 - Increased to 3 the output of Entertainer, Taxman and Scientist specialists (no longer increased by global effects of wonders).
@@ -45,9 +47,9 @@ Terrains:
   - Food resources (Seals, Oasis, Pheasant, Deer, Cattle, Corn, Fruit, Fish, Whales, Wheat, Buffalo, Sugar, Game): +1 unit free of upkeep in the receiving city.
   - Production resources (Oil, Wool, Cotton, Coal, Marble, Ivory, Iron, Salt, Horse, Peat; Niter, Rubber, Aluminum, Uranium): +1 Production in the receiving city.
 - Some units get additional veteran levels when certain resources are available in the city:
-  - Strategic resources (Horses, Ivory; Rubber, Aluminum, Uranium): +1 veteran level for certain units built in the city (or in any city linked by trade route).
+  - Strategic resources (Horses, Ivory; Rubber, Aluminum, Uranium): +1 veteran level for certain units built in the city (or in a city linked by trade route).
   * Key resources (Iron, Niter, Oil). For units that require Iron, Niter: -1 veteran level for each one of these resources that is not available in the city. For units that require Iron/Oil: -1 veteran level if none of these resources are available in the city, or 10% reduction in building cost if both are available in the city.
-- Power Plants require Oil resource available in the city. Nuclear Plants and Manhattan Project require Uranium. Apollo Program requires Aluminum.
+* Power Plants require Oil resource available in the city. Nuclear Plants and Manhattan Project require Uranium. Apollo Program no longer requires Aluminum.
 - Added Natural Wonders, that produce +2 Luxury points in the tile, and increase a bit the risk of natural disasters in a city. Marked with a text label and a red flag icon on the map. They are destroyed when the underlying terrain is transformed.
 
 Culture:
@@ -62,8 +64,8 @@ Governments:
 - New government: Fascism (available with Military Tactics, which requires Leadership and Conscription).
 - Empire Size no longer depends on the government chosen. Every time a new government becomes available, the Empire Size increases by 2, from 4 at the beginning, up to 20 when all governments have been discovered.
 * The number of content citizens, before the first unhappy one appears, is now 5 for most governments; 4 only for Despotism, Monarchy and Fundamentalism; 6 for Democracy and Federation.
-- Corruption and waste by distance are fixed to +2% per tile for ancient governments, +1% for modern governments, and +0% for Federation and Communism; no longer tied to the research of Trade or The Corporation techs.
-- Tribal (available with Warrior Code) gets 3 units per city free of upkeep, and extra vision range for ground units, instead of martial law.
+* Corruption and waste by distance are fixed to +4% per tile for Despotism and Tribalism, +2% for other ancient governments, +1% for modern governments, and +0% for Federation and Communism; no longer tied to the research of Trade or The Corporation techs.
+- Tribalism (available with Warrior Code) gets 3 units per city free of upkeep, and extra vision range for ground units, instead of martial law.
 - Despotism and Monarchy get a bonus to Luxury from the Palace (was Gold). Federation gets +2 Luxury points per city.
 - Republic and Democracy get the +1 Trade bonus only on tiles with an irrigation, and regardless if the tile wasn't producing any trade.
 * Fascism gets a +1 Gold bonus on each tile with a mine (including lumber, oil well and oil platform), instead of buildings free of upkeep.
@@ -74,6 +76,7 @@ Governments:
 - Fundamentalism no longer gets any penalty to Science output. Anarchy doesn't get any penalty to Luxury output.
 
 Techs:
+* Trade: cancels the output per tile penalty under Anarchy, Despotism and Tribalism; no longer tied to The Pyramids wonder or the research of Railroad.
 - Astronomy increases vision range of cities and fortresses. Electricity grants you vision within your borders.
 - Feudalism: allows to upgrade a Fortress to a Castle when it is inside your national borders. Castles protect full stacks from dying when one unit is defeated.
 - Medicine: allows non-wheeled ground units to recover 2 HP per turn, on plains or grassland, even without resting. Physics allows the same for wheeled units (on plains or grassland), and for naval units on shallow ocean.
@@ -125,7 +128,7 @@ Combat:
 
 Units:
 - Defense bonus of +25% for units stacked outside of cities, as long as there is any other unit on the same tile.
-* Wheeled units outside cities and bases receive up to +25% defense bonus from terrain (they don't take full advantage of defensive terrain with rivers, hills or mountains). Armor no longer receives extra defense against other Armor units.
+* Wheeled units outside cities receive defense bonus from terrain (not from rivers), but only up to +25%. Armor no longer receives extra defense against other Armor units.
 * Wheeled units on unroaded Jungle, Swamp or River start the turn with -1 movement point (as do all ground units on Mountains). Enemy roads (within the borders of a nation at war with you) don't avoid this penalty.
 * Wheeled units (Big Land class) can be loaded onto any cargo boat, including Galleys (but no Carriers and Submarines), and they can perform pillage. They can attack non-native tiles (mountains, jungles and swamps), and can bombard from shore to sea.
 - Increased the number of veteran levels by one, with the following effects: 100%, 125%, 150%, 175%, and 200%. Engineers up to 150%.
@@ -142,7 +145,7 @@ Units:
 * HP recover rate of units was simplified, and the effect of buildings was reduced: 10% resting, 35% in cities or full bases, 50% in cities with the appropiate military building. Non-mechanized units recover up to 65% HP in cities with both Barracks and Hospital.
 
 Naval units:
-- Defense bonus of +50% in Deep Ocean (or shallow Ocean adjacent to a Naval Mine) against Sea units (not against Submarines).
+* Defense bonus of +50% in Deep Ocean (or shallow Ocean adjacent to a Naval Mine) against naval units (except against Submarines).
 * Naval units adjacent to Naval Mines have a defense bonus only when not in enemy waters (within the borders of a nation you are at war with), and have a movement penalty only when not in friendly waters (within the borders of a nation you are not at war with).
 * Naval units lose all their movement points to move to enemy land tiles (via river/canal).
 * New unit Sailboat (available with Astronomy), which cannot attack, so it can move inside the borders of peaceful nations. It can enter deep oceans, but cannot end far from shore (on deep ocean surrounded by deep oceans) more than 1 consecutive turn.
@@ -157,14 +160,14 @@ Naval units:
 
 Wonders:
 - Readjusted effects and obsolescence of many wonders. See the table (in README file).
-- The construction of a wonder no longer requires the presence of other buildings in the city. This way, most wonders appear as available in every city, and it is easier to keep track of them. However, some wonders still require another building in the city in order to get the bonus, and some of them require adjacent water ("Lighthouse", "Magellan's Expedition", "Hoover Dam") or specific resources available in the city ("Manhattan Project", "Apollo Program" and "SETI Program").
+- The construction of a wonder no longer requires the presence of other buildings in the city. This way, most wonders appear as available in every city, and it is easier to keep track of them. However, some wonders still require another building in the city in order to get the bonus, and some of them require adjacent water ("Lighthouse", "Magellan's Expedition", "Hoover Dam") or a resource available in the city ("Manhattan Project").
 - Continental range: "J.S. Bach's Cathedral", "Great Wall" and "Sun Tzu's War Academy" affects only to cities of the same continent.
 - Global range: some minor effects, that may affect every player, added to "Cure For Cancer", "Internet", and "Women's Suffrage".
 * Every wonder produces as much culture per turn as its building cost/100.
 * Internet bonus simplified to +2 Science in your cities with a Research Lab (the result after summing the +200% from all science buildings can be up to +6 bulbs per city).
-* SETI Program, available with Radio, requires Rubber and allows a new way to achieve victory for every nation: when both the score and culture of a player are more than 4 times those of the 2nd best player.
+* SETI Program, available with Radio, allows a new way to achieve victory for every nation: when both the score and culture of a player are more than 4 times those of the 2nd best player.
 
 Future plans:
 * This might be the last version of the ruleset. Thanks to the impressive modding capabilities of Freeciv 3.1, I have finally been able to get the game balance that I like.
 * I will try to keep porting and fixing the ruleset for 3.2 and beyond, but if I don't, anyone can easily upgrade the ruleset to a new version thanks to the ruleup tool included in Freeciv releases.
-* The main pending tasks are to improve the helptexts, and to revise the balance of spy actions, air-to-air combat, and auto-attacking units.
+* The main pending tasks are to improve the helptexts, and to revise the balance of spy actions, and auto-attacking units.

--- a/3.1/civ2civ3_earth/README.ruleset_civ2civ3_earth
+++ b/3.1/civ2civ3_earth/README.ruleset_civ2civ3_earth
@@ -1,5 +1,5 @@
 ============================================================
-Civ2Civ3 Earth Ruleset for Freeciv v3.1 (Updated 05-2024)
+Civ2Civ3 Earth Ruleset for Freeciv v3.1 (Updated 12-2024)
 ============================================================
 
 "civ2civ3_earth" is a fork of the ruleset civ2civ3 (shipped with Freeciv since 2.5), from the same author. It includes new features, tries to improve balance, and is more suitable for playing on Earth maps, or similar scenarios. It includes its own tileset "amplio_earth", and a world map scenario, adapted to be played with these rules.
@@ -49,10 +49,10 @@ CORE CHANGES:
 
 - Allowed 1 trade route per city (2 after the discovery of The Corporation). Removed the one time revenues, and reduced the ongoing revenues. Trade routes with foreign cities receive 50% of the income, and only if the cities are allies (or on the same team).
 
-- Every unit (except Settlers, Migrants, and Fanatics, which cost population to build) pays some kind of upkeep cost. Some governments pay shields as upkeep, and others pay coins (similar to civ3), but not both.
+- Every unit pays some kind of upkeep cost (except Settlers, Migrants, and Fanatics, which cost population to build). Some governments pay shields as upkeep, and others pay coins (similar to civ3), but not both.
   A city cannot support more than 20 units (no matter if the city pays upkeep for the unit or not).
 
-- Most units also require upkeep in Food, except for Workers/Engineers, Diplomat/Spy, Caravan/Freight, Explorer/AWACS, and Cruise Missile/Nuclear.
+- Most units also require upkeep in Food (except for Workers/Engineers, Diplomat/Spy, Caravan/Freight, Explorer/AWACS, and Cruise Missile/Nuclear).
   A city can support for free as many units (with upkeep in Food) as its population size (at least 4 are always free). Additional units cause waste of Food. If the city shrinks due to starvation, one of those extra units will be disbanded.
 
 - Units lose one veteran level when upgraded, and they do not gain veterancy from combat if the enemy is not killed, or if either side of the fight is completely powerless.
@@ -98,7 +98,7 @@ CORE CHANGES:
 
 - Added a new barbarian nation that controls hostile animal units, randomly placed at the start of the game.
 
-- Added a new feature: Storms randomly appear and disappear on Deep Ocean or Glacier tiles, and they damage units ending the turn on an adjacent tile (or the same tile). Every unit entering the storm has its vision range reduced.
+- Added a new feature: Storms randomly appear (1%) and disappear (50%) on Deep Ocean or Glacier tiles, and they damage units ending the turn on an adjacent tile (or the same tile). Every unit entering the storm has its vision range reduced.
 
 
 OPTIONAL RULES:
@@ -229,7 +229,7 @@ Mountains -(36)---> Hills
 
 - Some units get additional veteran levels when certain resources are available in the city:
 
-  - Strategic resources (Horses, Ivory; Rubber, Aluminum, Uranium): +1 veteran level for certain units built in the city (or in any city linked by trade route).
+  - Strategic resources (Horses, Ivory; Rubber, Aluminum, Uranium): +1 veteran level for certain units built in the city (or in a city linked by trade route).
 
   - Key resources (Iron, Niter, Oil). For units that require Iron, Niter: -1 veteran level for each one of these resources that is not available in the city. For units that require Iron/Oil: -1 veteran level if none of these resources are available in the city, or 10% reduction in building cost if both are available in the city.
 
@@ -269,7 +269,7 @@ Output per tile * -1(if>2) -1(if>2) -1(if>2) -        -        -        -       
 Celebration Bonus (no -1)  (no -1)  (no -1) (+1Trade) -       (+1Trade)(+1Trade)(+1Trade) -        -
 
 Unit Upkeep       Shield   Shield   Coin     Coin     Coin(x2) Shield   Coin(x2) Coin(x2) Shield   Coin(x2)
-Free Units        2        3        2        3        2        1        1        2        3        3
+Free Units        3        3        2        3        2        1        1        2        3        3
 War Unhappiness   0        0        0       -1       -1       -1       -2       -1       -1        0
 Martial Law      +1        0       +1       +1        0        0        0        0       +2       +2
 
@@ -284,18 +284,18 @@ Special         +NoUpkeep +Vision  +75%Lux  +50%Lux  +Tithes  +1Trade  +1Trade  
 
 Base Corruption   0%      30%      20%      10%      15%      25%       5%       0%      30%      15%
 Base Waste       30%       0%      10%      20%      15%       5%      25%      30%       0%      15%
-by Distance      +2%      +2%      +2%      +2%      +2%      +2%      +1%      +0%      +0%      +1%
+by Distance      +4%      +4%      +4%      +2%      +2%      +2%      +1%      +0%      +0%      +1%
 
-*: The output per tile penalty is negated by The Pyramids wonder, or when Railroad is researched by any player.
+*: The output per tile penalty is negated when Trade is researched by the player.
 
-- Added Tribal (available with Warrior Code), Fundamentalism (available with Theology), Federation (available with Economics) and Fascism (available with Military Tactics).
+- Added Tribalism (available with Warrior Code), Fundamentalism (available with Theology), Federation (available with Economics) and Fascism (available with Military Tactics).
 
-- "Celebration bonus": Republic and Democracy get the usual +1 Trade on every tile already producing Trade (same as Monarchy and Federation). Tribal and Despotism get the usual removal of the -1 penalty when any tile output is greater than 2.
+- "Celebration bonus": Republic and Democracy get the usual +1 Trade on every tile already producing Trade (same as Monarchy and Federation). Tribalism and Despotism get the usual removal of the -1 penalty when any tile output is greater than 2.
   The other governments get a small bonus of +1 Trade only in the city center tile (if already producing Trade).
 
-- "Base Corruption/Waste": Modern governments cause less Corruption in Trade, but more Waste in Production. The total % lost (Waste + Corruption) is equal for all governments. Corruption and waste by distance are fixed to +2% per tile for ancient governments, +1% for modern governments, and +0% for Federation and Communism.
+- "Base Corruption/Waste": Modern governments cause less Corruption in Trade, but more Waste in Production. The total % lost (Waste + Corruption) is equal for all governments. Corruption and waste by distance are fixed to +4% per tile for Despotism and Tribalism, +2% for other ancient governments, +1% for modern governments, and +0% for Federation and Communism.
 
-- "Unit Upkeep": Tribal, Republic and Communism use the standard unit upkeep in shields, while the other governments use upkeep in coins (x2 coins per unit for modern governments).
+- "Unit Upkeep": Tribalism, Republic and Communism use the standard unit upkeep in shields, while the other governments use upkeep in coins (x2 coins per unit for modern governments).
 
 - "Free Units": Means units free of shield/coin upkeep and also free of unhappiness due to military activity. By default 2 free units per city.
 
@@ -320,7 +320,7 @@ by Distance      +2%      +2%      +2%      +2%      +2%      +2%      +1%      
 
 - Under Communism, you do not pay upkeep for buildings that cost 1 or 2 coins (they can be up to 31 coins with all buildings, but rarely more than 25).
 
-- Tribal and Fascism increase the chance of units to obtain the next veteran level after a battle. Every unit in the case of Fascism; only ground units in the case of Tribal, but they also get increased vision radius.
+- Tribalism and Fascism increase the chance of units to obtain the next veteran level after a battle. Every unit in the case of Fascism; only ground units in the case of Tribalism, but they also get increased vision radius.
 
 - Spies and Diplomats built under Federation or Communism will start at the first veteran level.
 
@@ -329,19 +329,19 @@ by Distance      +2%      +2%      +2%      +2%      +2%      +2%      +1%      
 - Under Fascism or Fundamentalism, citizens of enemy nationality cause extra unhappiness in the city (1 unhappy face for each 2 enemy citizens).
   When you conquer a city, 25% of the foreign population is converted to your nationality. After that, foreign population is converted at a pace of one population every 20 turns or so.
 
-TIP: There is some hurry to get Monarchy or Republic (or to build Pyramids), in order to avoid the initial penalty to output per tile. However, the differences are more subtle, and every government could be useful in some situation or stage of the game:
-- Tribal increases the vision range and the chance of units becoming veteran after a combat; but it uses shields to pay unit upkeep (Despotism uses gold which can be an advantage in some cases).
+TIP: There is some hurry to get Monarchy or Republic (or to research Trade), in order to avoid the initial penalty to output per tile. However, the differences are more subtle, and every government could be useful in some situation or stage of the game:
+- Tribalism increases the vision range and the chance of units becoming veteran after a combat; but it uses shields to pay unit upkeep (Despotism uses gold which can be an advantage in some cases).
 - Monarchy avoids the penalty to output per tile. It gives low unit upkeep costs, but units outside your borders may cause unhappiness.
 - Republic gets a bonus to trade on irrigated land; but it has a senate, units no longer impose martial law, and units outside your borders may cause unhappiness more easily.
 - Fundamentalism gets a significant bonus to gold production, especially useful when terrain is not favorable; but it receives no revenue from city celebrations, and science production is low even with taxes on science at maximum.
 - Democracy gets the same trade bonus on irrigated land as Republic, and reduces the corruption and waste caused by distance from the palace; but it has a senate, and it doubles the unhappiness caused by units outside your borders.
-  It can be the best government once city celebrations generate revenue (when they produce more trade than required to celebrate), especially when cities are surrounded by plains, grasslands or swamps.
+  It can be the best government once city celebrations generate revenue (when they produce more trade than required to celebrate), especially when cities are surrounded by plains, with some forests/hills on rivers.
 - Federation eliminates the corruption and waste caused by distance from the palace, and its bonus to luxury production allows cities to celebrate more easily; but it does not get the trade bonus from irrigated land.
   It is a good alternative to Democracy for larger empires or more aggressive wars, especially when cities are surrounded by sea (less irrigated or mined land, but more trade).
 - Communism also eliminates the corruption and waste caused by distance from the palace, and reduces considerably the gold paid for upkeep of buildings; but it receives no revenue from city celebrations.
-  It is a good alternative to Federation for post-industrial large empires, especially when cities are surrounded by hills/mountains or jungles/forests (less trade, but more production).
-- Fascism gets a bonus to gold production on mined land, increases the chance of units becoming veteran, and is the only modern government whose units can't cause unhappiness; but it has standard upkeep of buildings, and corruption and waste caused by distance is not eliminated.
-  It is a good alternative for militaristic nations, especially when cities are surrounded by a mix of grasslands and hills/forests (with more mines, and food enough to work them).
+  It is a good alternative to Federation for post-industrial large empires, especially when cities are surrounded by hills, mountains or jungles (less trade, but more production).
+- Fascism gets a bonus to gold production on mined land, increases the chance of units becoming veteran, and it is the only modern government whose units can't cause unhappiness; but it has standard upkeep of buildings, and corruption and waste caused by distance is not eliminated.
+  It is a good alternative for militaristic nations, especially when cities are surrounded by a mix of grasslands and forests/hills (with more mines, and food enough to work them).
 
 
 TECHS:
@@ -374,7 +374,7 @@ Special effects:
 - Explosives allow new terrain improvements: Naval Mines to increase the defense of shallow oceans and to reduce the movement of adjacent naval units; Canals to connect oceans separated by no more than 2 land tiles.
 - Electricity: Allows irrigation without adjacent water, improves the effect of Amphitheatres, and grants you vision within your borders.
 - Refining: Allows to upgrade mines to oil wells (+2 production) on Desert, Tundra and Glacier.
-- Trade: Allows 1 trade route per city.
+- Trade: Allows 1 trade route per city. Cancels the output per tile penalty under Anarchy, Despotism and Tribalism.
 - The Corporation: Allows 2 trade routes per city.
 - Labor Union: Engineers are built with +1 veteran level.
 - Computers: All cities on the map are continuously visible despite fog-of-war (once Internet wonder have been built by any player).
@@ -447,31 +447,26 @@ Recycling Center  140   2      -50%/-25%
 DEFENSE:
 --------
 
-- Halved the terrain defense bonuses, now more similar to civ3 values:
-
-TERRAIN                   NEW      CIV2
-Forest/Jungle/Swamp       +25%     +50%
-Hills                     +50%     +100%
-Mountains                 +100%    +200%
-
-RIVER                     +25%     +50%
-
 VETERAN
 Regular                   +25%
-Veteran                   +50%     (=)
-Hardened                  +75%     (=)
-Elite                     +100%    (=)
+Veteran                   +50%
+Hardened                  +75%
+Elite                     +100%
 
-FORTIFIED/FORTIFYING      +50%     +50%/+0%
+FORTIFIED/FORTIFYING      +50%
+
+TERRAIN                   (Non-wheeled ground units)
+Forest/Jungle/Swamp       +25%
+Hills                     +50%
+Mountains                 +100%
+
+RIVER                     +25%
 
 BASE             VS LAND  VS SEA   VS AIR   VS MISSILE
 Fort/Bombardment +50%     +50%      -        -
 Fortress/Castle  +100%    +100%    +50%     +50%
 Airstrip          -        -       +50%     +50%
 Airbase          +50%     +50%     +100%    +100%
-
-Ocean adjacent to Naval Mine,
-or Deep Ocean     -       +50%      -        -
 
 CITY
 Town (size<=8)   +50%     +50%      -        -
@@ -486,16 +481,27 @@ SDI Defense       -        -        -       +100%
 
 Great Wall       +50%      -        -        -
 
-OUTSIDE CITY
+OUTSIDE CITY (TERRAIN)
+Deep Ocean, or Ocean adjacent to Naval Mine
+Naval units       -       +50%      -        -
+
+Defensive terrain (Forest/Jungle/Swamp/Hills/Mountains)
+Wheeled units    +25%     +25%     +25%     +25%
+
+OUTSIDE CITY (STACK)
 Stack of units   +25%     +25%     +25%     +25%
 
 
-- Every unit receives a +25% defense bonus when it is stacked outside of cities, as long as there is another unit on the same tile.
+- Halved the terrain defense bonuses, now more similar to civ3 values.
 
 - Fortifying units receive the same +50% defense bonus as units already fortified. This allows both human and AI players to get the bonus in the same turn.
   Only military ground units can fortify. They need some remaining move fragment, while not being transported, to start fortifying; except inside cities, where they are always considered fortified.
 
-- Naval units on Deep Ocean, or shallow Ocean adjacent to a Naval Mine, receive a +50% defense bonus against Sea units (not against Galleys or Submarines).
+- Every unit receives a +25% defense bonus when it is stacked outside of cities, as long as there is another unit on the same tile.
+
+- Naval units on Deep Ocean, or shallow Ocean adjacent to a Naval Mine, receive a +50% defense bonus against other naval units (except against Submarines).
+
+- Wheeled units don't get the defense bonus from rivers, they only get defense bonuses from terrain outside cities, and only up to +25%.
 
 - Every city of any size receives an inherent +50% defense bonus against all ground and naval units (same as a fort).
 
@@ -507,16 +513,16 @@ Stack of units   +25%     +25%     +25%     +25%
 
 - Great Wall wonder gives an additional +50% defense bonus against ground units.
 
-Total Defense = (UNIT DEFENSE) * (100+TERRAIN)/100 * (100+RIVER)/100 * (100+CITY+BASE)/100 * (100+FORTIFIED)/100 * (100+VETERAN)/100
+Total Defense = (UNIT DEFENSE) * (100+TERRAIN)/100 * (100+RIVER)/100 * (100+CITY+BASE)/100 * (100+FORTIFIED)/100 * (100+VETERAN)/100 * (100+STACK)/100
 (Same as classic/civ2 rules).
 
-EXAMPLE: Riflemen fortified in a fortress, on mountains, with a river, will get a total defense of 30 against land attacks:
+EXAMPLE: Riflemen fortified in a fortress, on mountains, stacked with another unit, will get a total defense of 30 against land attacks:
 
          Riflemen: defense 4
          Fortified (+50%): 4 + 2 = 6
          In Fortress (+100%):      6 + 6 = 12
          On Mountains (+100%):             12 + 12 = 24
-         With River (+25%):                          24 + 6 = 30.
+         Stacked with other units (+25%):            24 + 6 = 30.
 
 EXAMPLE: Riflemen in a size 9 city, with walls, on hills, will get a total defense of 27 against land attacks:
 
@@ -596,8 +602,7 @@ Workers:   pop 0, cost 20, upkeep 1, food 0
 
 - New unit class for non-military units ("Small Land"), which can not capture cities, and does not create Zones of Control (ZOC) that would affect the movements of enemy units.
 
-- New unit class for large wheeled units ("Big Land"), which cannot move to rough terrain (Mountains, Jungles and Swamps) unless there is a road or base on the tile. They have -1 movement point if they start the turn on rough terrain or rivers without friendly roads. They do can attack these non native tiles (rough terrain), and can bombard from coastal land to sea.
-  They only get defense bonuses from the terrain outside cities and bases, and only up to +25% (they don't take full advantage of defensive terrain with rivers, hills or mountains). They are the only units that can cause loss of population when attacking a city (prevented by City Walls).
+- New unit class for large wheeled units ("Big Land"), which cannot move to rough terrain (Mountains, Jungles and Swamps) unless there is a road or base on the tile. They have -1 movement point if they start the turn on rough terrain or rivers without friendly roads. They do can attack these non native tiles (rough terrain), and can bombard from coastal land to sea. They are the only units that can cause loss of population when attacking a city (prevented by City Walls).
 
 - New unit class for mounted units ("Fast Land"), which are no longer slowed down when damaged. Infantry units keep their class ("Land").
 
@@ -641,7 +646,7 @@ The following unit changes are included in the table below:
 - Given Marine ability (named Raider) to Legion, Musketeer, and Rifleman. This way, one-tile islands can be assaulted early in game. Yet, the Marine unit is still the best offensive/defensive infantry.
 - Caravel changed from (2/1) to (1/2), in order to encourage peaceful exploration of the seas in the age of discovery. Galleon attack increased to 2 and no longer non-military.
 - Removed transport capability from Frigates, to force the use of Galleons. Reduced attack of Frigate and defense of Ironclad to 3 (was 4).
-- Battleship's hit points reduced to 30 (was 40), Ironclad and Submarine to 20 (was 30). Submarine defense increased to 4, and doubled against air attacks. Doubled the defense of Destroyers against Submarines. Now there is a Rock-paper-scissors relationship between Submarine-Destroyer-Cruiser.
+- Battleship's hit points reduced to 30 (was 40), Ironclad and Submarine to 20 (was 30). Submarine defense increased to 4, and doubled against air attacks. Doubled the defense of Destroyers against Submarines.
 - Naval units with transport capability don't cause unhappiness due to military activity, but their military cargo do cause unhappiness when deployed outside national borders, as usual.
 - All air units can cause unhappiness when they end the turn outside national borders. Nuclear missiles and air bombers cause unhappiness all the time, even inside national borders.
 - Air bombers and Helicopters have more hit points, but halved attack to make it harder to bombard enemies successfully.
@@ -720,11 +725,11 @@ In full base           35% Fortress   Deep Ocean)    35% Airbase
 RESTING INSIDE CITY    LAND           SEA            AIR
 Without improvement    35%            35%            35%
 With improvement       50% Barracks   50% Port       50% Airport
-(non mechanized)      +15% Hospital
+(non wheeled)         +15% Hospital
 
 EVERY TURN
 On plains, grassland or shallow ocean, with knowledge of:
-  Medicine (non mechanized units)                   +2 HP
+  Medicine (non wheeled ground units)               +2 HP
   Physics (wheeled or naval units)                  +2 HP
 
 On any oceanic or glacier tile adjacent to a Storm: -4 HP
@@ -755,7 +760,7 @@ FULL LIST OF WONDERS
 "Name", Cost, Requirements, Obsolescence, Effect.
 
 -=- "Pyramids" 200. Obsolete by Railroad (that increases even more the production):
-+1 Production per worked tile in the city (already producing shields). Disables the output per tile penalty under Despotism/Tribal governments.
++1 Production per worked tile in the city (already producing shields).
 -=- "Colossus" 200. Obsolete by Automobile (Super Highways):
 +1 Trade per worked tile in the city (already producing Trade).
 -=- "Copernicus' Observatory" 300. Obsolete by Radio:
@@ -820,13 +825,13 @@ Ignores the effect of having a senate. Any government available. No Anarchy peri
 -=- "Hoover Dam" 600. Requires adjacent river:
 Gives to all your Hydro Plants the same effect as Solar Plants (-25% pollution caused by production). Doubles the bonus to production of an Hydro Plant in the city (+50% Production).
 
---- (#)"SETI Program" 600. Requires Rubber:
-# Enables a new victory condition for every nation: when a nation's score and culture are more than 4 times the second-highest.
 --- (#)"Manhattan Project" 600. Requires Uranium:
 # Enables Nuclear units for every nation.
---- (#)"Apollo Program" 600. Requires Aluminum:
+--- (#)"Apollo Program" 600:
 Makes the entire map (but not the units) permanently visible for the owner.
 # Enables space race for every nation.
+--- (#)"SETI Program" 600:
+# Enables a new victory condition for every nation: when a nation's score and culture are more than 4 times the second-highest.
 -=- (#)"United Nations" 600:
 +1 Veteran level for Diplomats and Spies built in the city.
 # Embassy with all players for every nation. Revolution when unhappy effect for every nation.

--- a/3.1/civ2civ3_earth/buildings.ruleset
+++ b/3.1/civ2civ3_earth/buildings.ruleset
@@ -1401,7 +1401,6 @@ genus		= "GreatWonder"
 reqs	=
     { "type", "name", "range"
       "Tech", "Space Flight", "Player"
-      "Extra", "Aluminum", "Traderoute"
     }
 graphic	= "b.apollo_program"
 graphic_alt	= "-"
@@ -1956,10 +1955,7 @@ sound		= "w_pyramids"
 sound_alt	= "w_generic"
 helptext	= _("\
 Each tile around the city where this wonder is built that is already \
-generating some shield output produces one extra shield resource. \
-Under Despotism or Tribal governments, the Pyramids cancel the penalty \
-to worked tiles with output greater than 2 (for all kinds of output), \
-as if all your cities were always celebrating.\
+generating some shield output produces one extra shield resource.\
 ")
 
 [building_seti_program]
@@ -1968,7 +1964,6 @@ genus		= "GreatWonder"
 reqs	=
     { "type", "name", "range"
       "Tech", "Radio", "Player"
-      "Extra", "Rubber", "Traderoute"
     }
 graphic	= "b.seti_program"
 graphic_alt	= "-"

--- a/3.1/civ2civ3_earth/effects.ruleset
+++ b/3.1/civ2civ3_earth/effects.ruleset
@@ -388,7 +388,8 @@ value   = 50
 reqs    =
     { "type", "name", "range", "present"
       "Terrain", "Deep Ocean", "Local", TRUE
-      "UnitClass", "Sea", "Local", TRUE
+      "UnitClassFlag", "Naval", "Local", TRUE
+      "UnitClass", "Sub", "Local", FALSE
     }
 
 ; WARNING
@@ -406,7 +407,8 @@ reqs    =
       "Extra", "Naval Mine", "Adjacent", TRUE
       "TerrainClass", "Oceanic", "Local", TRUE
       "Terrain", "Deep Ocean", "Local", FALSE
-      "UnitClass", "Sea", "Local", TRUE
+      "UnitClassFlag", "Naval", "Local", TRUE
+      "UnitClass", "Sub", "Local", FALSE
       "DiplRelTile", "War", "Local", FALSE
     }
 
@@ -418,7 +420,8 @@ reqs    =
       "Extra", "Naval Mine", "Adjacent", TRUE
       "TerrainClass", "Oceanic", "Local", TRUE
       "Terrain", "Deep Ocean", "Local", FALSE
-      "UnitClass", "Sea", "Local", TRUE
+      "UnitClassFlag", "Naval", "Local", TRUE
+      "UnitClass", "Sub", "Local", FALSE
       "CityTile", "Claimed", "Local", FALSE
     }
 
@@ -602,6 +605,7 @@ reqs    =
     }
 
 ; City: against every land and sea
+; City defense is equal to a Fort
 [effect_city_defense_0]
 type    = "Defend_Bonus"
 value   = 50
@@ -612,6 +616,7 @@ reqs    =
     }
 
 ; City (size > 8): against every land and sea
+; 50 + 50 = 100
 [effect_city_defense_1]
 type    = "Defend_Bonus"
 value   = 50
@@ -663,7 +668,7 @@ reqs    =
       "CityTile", "Center", "Local", FALSE
     }
 
-; Wheeled: +25% defense outside of cities and bases
+; Wheeled: +25% defense outside of cities
 ; (on any terrain with defense bonus)
 [effect_wheeled_defense]
 type    = "Fortify_Defense_Bonus"
@@ -674,8 +679,6 @@ reqs    =
       "UnitClassFlag", "TerrainDefense", "Local", FALSE
       "Activity", "Fortified", "Local", FALSE
       "Activity", "Fortifying", "Local", FALSE
-      "Extra", "Fort", "Local", FALSE
-      "Extra", "Airstrip", "Local", FALSE
       "CityTile", "Center", "Local", FALSE
       "TerrainFlag", "Defense", "Local", TRUE
     }
@@ -691,8 +694,6 @@ reqs    =
       "UnitFlag", "Wheeled", "Local", TRUE
       "UnitClassFlag", "TerrainDefense", "Local", FALSE
       "Activity", "Fortified", "Local", TRUE
-      "Extra", "Fort", "Local", FALSE
-      "Extra", "Airstrip", "Local", FALSE
       "CityTile", "Center", "Local", FALSE
       "TerrainFlag", "Defense", "Local", TRUE
     }
@@ -705,58 +706,8 @@ reqs    =
       "UnitFlag", "Wheeled", "Local", TRUE
       "UnitClassFlag", "TerrainDefense", "Local", FALSE
       "Activity", "Fortifying", "Local", TRUE
-      "Extra", "Fort", "Local", FALSE
-      "Extra", "Airstrip", "Local", FALSE
       "CityTile", "Center", "Local", FALSE
       "TerrainFlag", "Defense", "Local", TRUE
-    }
-
-; Wheeled: +25% defense outside of cities and bases
-; (on river and terrain with no defense bonus)
-[effect_wheeled_defense_river]
-type    = "Fortify_Defense_Bonus"
-value   = 25
-reqs    =
-    { "type", "name", "range", "present"
-      "UnitFlag", "Wheeled", "Local", TRUE
-      "UnitClassFlag", "TerrainDefense", "Local", FALSE
-      "Activity", "Fortified", "Local", FALSE
-      "Activity", "Fortifying", "Local", FALSE
-      "Extra", "River", "Local", TRUE
-      "Extra", "Fort", "Local", FALSE
-      "Extra", "Airstrip", "Local", FALSE
-      "CityTile", "Center", "Local", FALSE
-      "TerrainFlag", "Defense", "Local", FALSE
-    }
-
-[effect_wheeled_defense_river_1]
-type    = "Fortify_Defense_Bonus"
-value   = 37
-reqs    =
-    { "type", "name", "range", "present"
-      "UnitFlag", "Wheeled", "Local", TRUE
-      "UnitClassFlag", "TerrainDefense", "Local", FALSE
-      "Activity", "Fortified", "Local", TRUE
-      "Extra", "River", "Local", TRUE
-      "Extra", "Fort", "Local", FALSE
-      "Extra", "Airstrip", "Local", FALSE
-      "CityTile", "Center", "Local", FALSE
-      "TerrainFlag", "Defense", "Local", FALSE
-    }
-
-[effect_wheeled_defense_river_2]
-type    = "Fortify_Defense_Bonus"
-value   = 37
-reqs    =
-    { "type", "name", "range", "present"
-      "UnitFlag", "Wheeled", "Local", TRUE
-      "UnitClassFlag", "TerrainDefense", "Local", FALSE
-      "Activity", "Fortifying", "Local", TRUE
-      "Extra", "River", "Local", TRUE
-      "Extra", "Fort", "Local", FALSE
-      "Extra", "Airstrip", "Local", FALSE
-      "CityTile", "Center", "Local", FALSE
-      "TerrainFlag", "Defense", "Local", FALSE
     }
 
 [effect_fortified]
@@ -954,9 +905,9 @@ reqs    =
 type    = "Move_Bonus"
 value   = 8
 reqs    =
-    { "type", "name", "range", "present"
-      "Building", "Airport", "City", TRUE
-      "UnitType", "Nuclear", "Local", TRUE
+    { "type", "name", "range"
+      "Building", "Airport", "City"
+      "UnitType", "Nuclear", "Local"
     }
 
 ; Rocketry enables the movement of nuclear weapons,
@@ -1178,9 +1129,49 @@ reqs    =
       "NationGroup", "Barbarian", "Player", FALSE
     }
 
+; Trade waste -4% each tile
+[effect_corruption_distance]
+type    = "Output_Waste_By_Distance"
+value   = 400
+reqs    =
+    { "type", "name", "range", "present"
+      "OutputType", "Trade", "Local", TRUE
+;      "Gov", "Anarchy", "Player", FALSE
+;      "Gov", "Tribal", "Player", FALSE
+;      "Gov", "Despotism", "Player", FALSE
+      "Gov", "Monarchy", "Player", FALSE
+      "Gov", "Fascism", "Player", FALSE
+      "Gov", "Communism", "Player", FALSE
+      "Gov", "Fundamentalism", "Player", FALSE
+      "Gov", "Federation", "Player", FALSE
+      "Gov", "Republic", "Player", FALSE
+      "Gov", "Democracy", "Player", FALSE
+      "NationGroup", "Barbarian", "Player", FALSE
+    }
+
+; Trade waste -2% each tile
+[effect_corruption_distance_ancient]
+type    = "Output_Waste_By_Distance"
+value   = 200
+reqs    =
+    { "type", "name", "range", "present"
+      "OutputType", "Trade", "Local", TRUE
+      "Gov", "Anarchy", "Player", FALSE
+      "Gov", "Tribal", "Player", FALSE
+      "Gov", "Despotism", "Player", FALSE
+;      "Gov", "Monarchy", "Player", FALSE
+      "Gov", "Fascism", "Player", FALSE
+      "Gov", "Communism", "Player", FALSE
+;      "Gov", "Fundamentalism", "Player", FALSE
+      "Gov", "Federation", "Player", FALSE
+;      "Gov", "Republic", "Player", FALSE
+      "Gov", "Democracy", "Player", FALSE
+      "NationGroup", "Barbarian", "Player", FALSE
+    }
+
 ; Trade waste -1% each tile
 ; (Federation and Communism 0%)
-[effect_corruption_distance]
+[effect_corruption_distance_modern]
 type    = "Output_Waste_By_Distance"
 value   = 100
 reqs    =
@@ -1196,26 +1187,6 @@ reqs    =
       "Gov", "Federation", "Player", FALSE
       "Gov", "Republic", "Player", FALSE
 ;      "Gov", "Democracy", "Player", FALSE
-      "NationGroup", "Barbarian", "Player", FALSE
-    }
-
-; Trade waste -2% each tile
-[effect_corruption_distance_ancient]
-type    = "Output_Waste_By_Distance"
-value   = 200
-reqs    =
-    { "type", "name", "range", "present"
-      "OutputType", "Trade", "Local", TRUE
-;      "Gov", "Anarchy", "Player", FALSE
-;      "Gov", "Tribal", "Player", FALSE
-;      "Gov", "Despotism", "Player", FALSE
-;      "Gov", "Monarchy", "Player", FALSE
-      "Gov", "Fascism", "Player", FALSE
-      "Gov", "Communism", "Player", FALSE
-;      "Gov", "Fundamentalism", "Player", FALSE
-      "Gov", "Federation", "Player", FALSE
-;      "Gov", "Republic", "Player", FALSE
-      "Gov", "Democracy", "Player", FALSE
       "NationGroup", "Barbarian", "Player", FALSE
     }
 
@@ -1311,8 +1282,48 @@ reqs    =
       "OutputType", "Trade", "Local", FALSE
     }
 
-; Production waste -1% shields each tile
+; Production waste -4% shields each tile
 [effect_waste_distance]
+type    = "Output_Waste_By_Distance"
+value   = 400
+reqs    =
+    { "type", "name", "range", "present"
+      "OutputType", "Shield", "Local", TRUE
+;      "Gov", "Anarchy", "Player", FALSE
+;      "Gov", "Tribal", "Player", FALSE
+;      "Gov", "Despotism", "Player", FALSE
+      "Gov", "Monarchy", "Player", FALSE
+      "Gov", "Fascism", "Player", FALSE
+      "Gov", "Communism", "Player", FALSE
+      "Gov", "Fundamentalism", "Player", FALSE
+      "Gov", "Federation", "Player", FALSE
+      "Gov", "Republic", "Player", FALSE
+      "Gov", "Democracy", "Player", FALSE
+      "NationGroup", "Barbarian", "Player", FALSE
+    }
+
+; Production waste -2% shields each tile
+[effect_waste_distance_ancient]
+type    = "Output_Waste_By_Distance"
+value   = 200
+reqs    =
+    { "type", "name", "range", "present"
+      "OutputType", "Shield", "Local", TRUE
+      "Gov", "Anarchy", "Player", FALSE
+      "Gov", "Tribal", "Player", FALSE
+      "Gov", "Despotism", "Player", FALSE
+;      "Gov", "Monarchy", "Player", FALSE
+      "Gov", "Fascism", "Player", FALSE
+      "Gov", "Communism", "Player", FALSE
+;      "Gov", "Fundamentalism", "Player", FALSE
+      "Gov", "Federation", "Player", FALSE
+;      "Gov", "Republic", "Player", FALSE
+      "Gov", "Democracy", "Player", FALSE
+      "NationGroup", "Barbarian", "Player", FALSE
+    }
+
+; Production waste -1% shields each tile
+[effect_waste_distance_modern]
 type    = "Output_Waste_By_Distance"
 value   = 100
 reqs    =
@@ -1328,26 +1339,6 @@ reqs    =
       "Gov", "Federation", "Player", FALSE
       "Gov", "Republic", "Player", FALSE
 ;      "Gov", "Democracy", "Player", FALSE
-      "NationGroup", "Barbarian", "Player", FALSE
-    }
-
-; Production waste -2% shields each tile
-[effect_waste_distance_ancient]
-type    = "Output_Waste_By_Distance"
-value   = 200
-reqs    =
-    { "type", "name", "range", "present"
-      "OutputType", "Shield", "Local", TRUE
-;      "Gov", "Anarchy", "Player", FALSE
-;      "Gov", "Tribal", "Player", FALSE
-;      "Gov", "Despotism", "Player", FALSE
-;      "Gov", "Monarchy", "Player", FALSE
-      "Gov", "Fascism", "Player", FALSE
-      "Gov", "Communism", "Player", FALSE
-;      "Gov", "Fundamentalism", "Player", FALSE
-      "Gov", "Federation", "Player", FALSE
-;      "Gov", "Republic", "Player", FALSE
-      "Gov", "Democracy", "Player", FALSE
       "NationGroup", "Barbarian", "Player", FALSE
     }
 
@@ -1613,7 +1604,7 @@ reqs    =
 
 [effect_upkeep_free_units_anarchy]
 type    = "Unit_Upkeep_Free_Per_City"
-value   = 2
+value   = 3
 reqs    =
     { "type", "name", "range", "quiet"
       "Gov", "Anarchy", "Player", TRUE
@@ -2296,15 +2287,13 @@ reqs    =
       "Gov", "Democracy", "Player", FALSE
     }
 
-; Railroad because makes Pyramids obsolete
 [effect_gov_tile_penalty_anarchy]
 type    = "Output_Penalty_Tile"
 value   = 2
 reqs    =
     { "type", "name", "range", "present", "quiet"
-      "Gov", "Anarchy", "Player", TRUE, TRUE
-      "Building", "Pyramids", "Player", FALSE, FALSE
-      "Tech", "Railroad", "World", FALSE, FALSE
+      "Gov", "Anarchy", "Player", TRUE, FALSE
+      "Tech", "Trade", "Player", FALSE, FALSE
       "OutputType", "Gold", "Local", FALSE, TRUE
       "OutputType", "Luxury", "Local", FALSE, TRUE
       "OutputType", "Science", "Local", FALSE, TRUE
@@ -2315,9 +2304,8 @@ type    = "Output_Penalty_Tile"
 value   = 2
 reqs    =
     { "type", "name", "range", "present", "quiet"
-      "Gov", "Tribal", "Player", TRUE, TRUE
-      "Building", "Pyramids", "Player", FALSE, FALSE
-      "Tech", "Railroad", "World", FALSE, FALSE
+      "Gov", "Tribal", "Player", TRUE, FALSE
+      "Tech", "Trade", "Player", FALSE, FALSE
       "OutputType", "Gold", "Local", FALSE, TRUE
       "OutputType", "Luxury", "Local", FALSE, TRUE
       "OutputType", "Science", "Local", FALSE, TRUE
@@ -2328,9 +2316,8 @@ type    = "Output_Penalty_Tile"
 value   = 2
 reqs    =
     { "type", "name", "range", "present", "quiet"
-      "Gov", "Despotism", "Player", TRUE, TRUE
-      "Building", "Pyramids", "Player", FALSE, FALSE
-      "Tech", "Railroad", "World", FALSE, FALSE
+      "Gov", "Despotism", "Player", TRUE, FALSE
+      "Tech", "Trade", "Player", FALSE, FALSE
       "OutputType", "Gold", "Local", FALSE, TRUE
       "OutputType", "Luxury", "Local", FALSE, TRUE
       "OutputType", "Science", "Local", FALSE, TRUE
@@ -2414,26 +2401,6 @@ reqs    =
 ;      "Gov", "Federation", "Player", FALSE
 ;      "Gov", "Republic", "Player", FALSE
 ;      "Gov", "Democracy", "Player", FALSE
-    }
-
-; Celebration: only city center tile
-[effect_gov_tile_bonus_celebrate_center]
-type    = "Output_Inc_Tile_Celebrate"
-value   = 1
-reqs    =
-    { "type", "name", "range", "present"
-      "OutputType", "Trade", "Local", TRUE
-      "CityTile", "Center", "Local", TRUE
-      "Gov", "Anarchy", "Player", FALSE
-      "Gov", "Tribal", "Player", FALSE
-      "Gov", "Despotism", "Player", FALSE
-      "Gov", "Monarchy", "Player", FALSE
-;      "Gov", "Fascism", "Player", FALSE
-;      "Gov", "Communism", "Player", FALSE
-;      "Gov", "Fundamentalism", "Player", FALSE
-      "Gov", "Federation", "Player", FALSE
-      "Gov", "Republic", "Player", FALSE
-      "Gov", "Democracy", "Player", FALSE
     }
 
 [effect_vision_tribal]

--- a/3.1/civ2civ3_earth/game.ruleset
+++ b/3.1/civ2civ3_earth/game.ruleset
@@ -26,7 +26,7 @@ description_file = "civ2civ3_earth/README.ruleset_civ2civ3_earth"
 name = _("Civ2Civ3 Earth ruleset")
 
 ; There`s no separate versioning in rulesets part of main freeciv distribution
-version = "3.1_2024_05"
+version = "3.1_2024_05b"
 
 ; When about to migrate ruleset under a new name in the future version, set
 ; alt_dir to the name of that future directory. Then savegames saved with this

--- a/3.1/civ2civ3_earth/governments.ruleset
+++ b/3.1/civ2civ3_earth/governments.ruleset
@@ -79,8 +79,8 @@ Anarchy is simply the absence of any recognizable government.\
 _("\
 * Buildings and technologies do not require any upkeep.\n\
 * Each worked tile that gives more than 2 Food, Production, or Trade will\
- suffer a -1 penalty, unless the city working it is celebrating.\
- (Cities below size 3 will not celebrate.)\n\
+ suffer a -1 penalty, unless the player has researched Trade technology,\
+ or the city is celebrating. (Cities below size 3 will not celebrate.)\n\
 * All citizens are unhappy by default.\n\
 * Each city can support up to 2 units for free; further units each cost\
  1 shield per turn.\n\
@@ -98,7 +98,8 @@ _("\
 ;------------------------------------------------------------------------
 [government_tribal]
 
-name        = _("Tribal")
+name        = _("Tribalism")
+rule_name   = _("Tribal")
 reqs = { "type", "name", "range"
          "tech", "Warrior Code", "Player"
        }
@@ -110,10 +111,10 @@ ruler_male_title = _("Warlord %s")
 ruler_female_title = _("Warlady %s")
 
 helptext = _("\
-Under a Tribal government, you are part ruler of your people. Your\
- control over your citizens is maintained largely by spiritual counsel.\
+Under Tribalism, you are part ruler of your people. Your control over\
+ your citizens is maintained largely by spiritual counsel.\
 "), _("\
-Compared to Despotism, a Tribal economy is more shield-oriented. Its\
+Compared to Despotism, a tribal economy is more shield-oriented. Its\
  bonuses to veterancy and vision range can be an advantage in wartime,\
  but it lacks the martial law of other early governments.\
 "),
@@ -122,8 +123,8 @@ _("\
 * Increases by half the chance of land units to obtain the next veteran\
  level after a battle, and also increases their vision range.\n\
 * Each worked tile that gives more than 2 Food, Production, or Trade will\
- suffer a -1 penalty, unless the city working it is celebrating.\
- (Cities below size 3 will not celebrate.)\n\
+ suffer a -1 penalty, unless the player has researched Trade technology,\
+ or the city is celebrating. (Cities below size 3 will not celebrate.)\n\
 * The first 5 citizens of each city are content by default.\
  The 6th citizen will be the first unhappy one.\n\
 * Each city can support up to 3 units for free; further units each cost\
@@ -133,7 +134,7 @@ _("\
 * Base corruption is 30% (the highest under any government). This\
  increases by 2% for each tile of distance from the capital.\n\
 * There is no base level of production waste, but it increases\
- by 2% for each tile of distance from the capital.\n\
+ by 2% for each tile of distance from the capital.\
 ")
 
 ;------------------------------------------------------------------------
@@ -159,8 +160,8 @@ _("\
 * Your centers of government (cities with Palace and Ecclesiastical\
  Palace) get a +75% bonus to luxury production.\n\
 * Each worked tile that gives more than 2 Food, Production, or Trade will\
- suffer a -1 penalty, unless the city working it is celebrating.\
- (Cities below size 3 will not celebrate.)\n\
+ suffer a -1 penalty, unless the player has researched Trade technology,\
+ or the city is celebrating. (Cities below size 3 will not celebrate.)\n\
 * The first 4 citizens of each city are content by default.\
  The 5th citizen will be the first unhappy one.\n\
 * Each city can support up to 2 units for free; further units each cost\
@@ -238,8 +239,8 @@ Communism eliminates the corruption and waste caused by distance from\
  buildings; but it does not get the trade bonus from irrigated land\
  or city celebrations.\
 "), _("\
-It is a good alternative to Federation for large empires, especially\
- when cities are surrounded by hills, mountains, jungles or forests\
+It is a good alternative to Federation for post-industrial large empires,\
+ especially when cities are surrounded by hills, mountains or jungles\
  (less trade, but more production).\
 "),
 ; /* xgettext:no-c-format */
@@ -287,8 +288,8 @@ Improvements that normally convert unhappy citizens to content\
  of people they would convert.\
 "), _("\
 Fundamentalism gets a significant bonus to gold production, especially\
- useful when terrain is not favorable for trade; but city celebrations\
- give no revenues, and science production is low even with taxes on\
+ useful when terrain is not favorable; but it receives no revenue from\
+ city celebrations, and science production is low even with taxes on\
  science at maximum.\
 "),
 ; /* xgettext:no-c-format */
@@ -329,7 +330,7 @@ Federation eliminates the corruption and waste caused by distance from\
 "), _("\
 It is a good alternative to Democracy for larger empires or more\
  aggressive wars, especially when cities are surrounded by sea (less\
- land, but more trade).\
+ irrigated or mined land, but more trade).\
 "),
 ; /* xgettext:no-c-format */
 _("\
@@ -343,7 +344,7 @@ _("\
  each further unit causes 1 unhappy citizen.\n\
 * There is no corruption.\n\
 * Base production waste is 30%, but is not affected by distance to the\
- capital.\n\
+ capital.\
 ")
 
 ;------------------------------------------------------------------------
@@ -385,7 +386,7 @@ irrigation.\n\
 * Base corruption is 25%. This increases by 2% for each tile of distance\
  from the capital.\n\
 * Base production waste is 5%. This increases by 2% for each tile of\
- distance from the capital.\
+ distance from the capital.\n\
 * Has a senate that may prevent declaration of war.\
 ")
 
@@ -413,8 +414,9 @@ Democracy gets the same trade bonus on irrigated land as Republic,\
  palace; but it has a senate, and it doubles the unhappiness caused\
  by units outside your borders.\
 "), _("\
-It is the best government once city celebrations give revenues (when\
- they produce more trade than the required to celebrate).\
+It can be the best government once city celebrations generate revenue\
+ (when they produce more trade than the required to celebrate),\
+ especially when cities are surrounded by plains and rivers.\
 "),
 ; /* xgettext:no-c-format */
 _("\
@@ -452,13 +454,14 @@ Fascism seeks to solve economic, political, and social problems by\
  achieving a national rebirth, exalting the nation or race above all\
  else, and promoting cults of unity, strength, and purity.\
 "), _("\
-Fascism avoids the upkeep costs of many buildings like Communism,\
- increases the chance of units becoming veteran, and it is the only\
- modern government whose units can't cause unhappiness; but corruption\
- and waste caused by distance is not eliminated.\
+Fascism gets a bonus to gold production on mined land, increases the\
+ chance of units becoming veteran, and it is the only modern government\
+ whose units can't cause unhappiness; but it has standard upkeep of\
+ buildings, and corruption and waste caused by distance is not eliminated.\
 "), _("\
-It is a good alternative for militaristic nations, especially when city\
- celebrations are not worth the cost.\
+It is a good alternative for militaristic nations, especially when\
+ cities are surrounded by a mix of grasslands and hills or forests\
+ (more mines, and food enough to work them).\
 "),
 ; /* xgettext:no-c-format */
 _("\
@@ -475,7 +478,7 @@ _("\
 * Base corruption is 15%. This increases by 1% for each tile of distance\
  from the capital.\n\
 * Base production waste is 15%. This increases by 1% for each tile of\
- distance from the capital.\n\
+ distance from the capital.\
 ")
 
 ; /* <-- avoid gettext warnings

--- a/3.1/civ2civ3_earth/script.lua
+++ b/3.1/civ2civ3_earth/script.lua
@@ -451,6 +451,7 @@ function score_victory(turn, year)
       local culture = player:culture()
 
       if score > score_1st then
+        score_2nd = score_1st
         score_1st = score
         -- save the score leader, that might not be the culture leader
         leader = player
@@ -458,6 +459,7 @@ function score_victory(turn, year)
         score_2nd = score
       end
       if culture > culture_1st then
+        culture_2nd = culture_1st
         culture_1st = culture
       elseif culture > culture_2nd then
         culture_2nd = culture

--- a/3.1/civ2civ3_earth/techs.ruleset
+++ b/3.1/civ2civ3_earth/techs.ruleset
@@ -225,7 +225,6 @@ helptext = _("\
 Rubber resources produce 2 extra shields in the tile where they are \
 located.\
 "), _("\
-Rubber is required in a city to build the wonder SETI Program. \
 Cities with available Rubber build Marines, Paratroopers, Helicopter, \
 Mech. Inf. and Howitzer units with one extra veteran level.\
 ")
@@ -519,7 +518,6 @@ helptext = _("\
 Aluminum resources produce 2 extra shields in the tile where they are \
 located.\
 "), _("\
-Aluminum is required in a city to build the wonder Apollo Program. \
 Cities with available Aluminum build Carrier, AEGIS Cruiser, Cruise \
 Missile, Fighter and Bomber units with one extra veteran level.\
 ")
@@ -828,10 +826,6 @@ graphic_alt = "-"
 helptext = _("\
 Allows Settlers, Migrants, Workers and Engineers to upgrade roads to \
 railroads.\
-"), _("\
-For Despotism or Tribal governments, cancels the penalty to worked \
-tiles with output greater than 2 (as if all your cities were always \
-celebrating).\
 ")
 ;cost     = 350
 
@@ -1049,6 +1043,9 @@ flags    = ""
 graphic     = "a.trade"
 graphic_alt = "-"
 helptext = _("\
+Cancels the penalty to output per tile caused by Anarchy, Despotism \
+or Tribalism governments.\
+"), _("\
 Allows establishing up to 1 trade route from each city.\
 "), _("\
 When 2 cities are linked by a trade route, any special resource present \

--- a/3.1/civ2civ3_earth/terrain.ruleset
+++ b/3.1/civ2civ3_earth/terrain.ruleset
@@ -1262,7 +1262,7 @@ rmact_gfx      = "None"
 rmact_gfx_alt  = "-"
 reqs           =
     { "type", "name", "range", "present", "quiet"
-      "UnitFlag", "CanWork", "Local", TRUE, FALSE
+      "UnitFlag", "CanWork", "Local", TRUE, TRUE
     }
 build_time     = 0
 removal_time   = 0
@@ -1307,8 +1307,8 @@ rmact_gfx_alt  = "-"
 reqs           =
     { "type", "name", "range", "present", "quiet"
       "TerrainFlag", "Wood", "Local", FALSE, TRUE
-      "TerrainClass", "Oceanic", "Local", FALSE, TRUE
-      "UnitFlag", "CanWork", "Local", TRUE, FALSE
+      "TerrainClass", "Land", "Local", TRUE, FALSE
+      "UnitFlag", "CanWork", "Local", TRUE, TRUE
     }
 build_time     = 0
 removal_time   = 0
@@ -1338,8 +1338,8 @@ rmact_gfx      = "None"
 rmact_gfx_alt  = "-"
 reqs           =
     { "type", "name", "range", "present", "quiet"
-      "TerrainFlag", "Wood", "Local", TRUE, TRUE
-      "UnitFlag", "CanWork", "Local", TRUE, FALSE
+      "TerrainFlag", "Wood", "Local", TRUE, FALSE
+      "UnitFlag", "CanWork", "Local", TRUE, TRUE
     }
 build_time     = 0
 removal_time   = 0
@@ -1365,9 +1365,9 @@ rmact_gfx_alt  = "-"
 reqs           =
     { "type", "name", "range", "present", "quiet"
       "Tech", "Refining", "Player", TRUE, FALSE
-      "TerrainFlag", "Oil", "Local", TRUE, TRUE
+      "TerrainFlag", "Oil", "Local", TRUE, FALSE
       "Extra", "Mine", "Local", TRUE, FALSE
-      "UnitFlag", "CanWork", "Local", TRUE, FALSE
+      "UnitFlag", "CanWork", "Local", TRUE, TRUE
     }
 build_time     = 0
 removal_time   = 0
@@ -1512,11 +1512,11 @@ rmact_gfx_alt  = "-"
 ; Note, there are extra restrictions on where farmland can be built
 ; through "Build Irrigation" action enablers
 reqs           =
-    { "type", "name", "range", "present"
-      "Tech", "Refrigeration", "Player", TRUE
-      "Extra", "Irrigation", "Local", TRUE
-      "UnitFlag", "CanWork", "Local", TRUE
-      "CityTile", "Center", "Local", FALSE
+    { "type", "name", "range", "present", "quiet"
+      "Tech", "Refrigeration", "Player", TRUE, FALSE
+      "Extra", "Irrigation", "Local", TRUE, FALSE
+      "UnitFlag", "CanWork", "Local", TRUE, TRUE
+      "CityTile", "Center", "Local", FALSE, TRUE
     }
 build_time     = 0
 removal_time   = 0
@@ -1665,10 +1665,11 @@ reqs           =
     { "type", "name", "range", "present", "quiet"
       "Extra", "Fortress", "Local", TRUE, FALSE
       "Tech", "Feudalism", "Player", TRUE, FALSE
-      "UnitFlag", "CanWork", "Local", TRUE, FALSE
+      "UnitFlag", "CanWork", "Local", TRUE, TRUE
       "DiplRelTile", "Foreign", "Local", FALSE, FALSE
-      "TerrainFlag", "NoCities", "Local", FALSE, FALSE
-      "CityTile", "Center", "Adjacent", FALSE, FALSE
+      "Terrain", "Glacier", "Local", FALSE, FALSE
+      "Terrain", "Mountains", "Local", FALSE, FALSE
+      "CityTile", "Center", "Adjacent", FALSE, TRUE
       "Extra", "Castle", "Adjacent", FALSE, FALSE
     }
 disappearance_reqs =
@@ -1711,7 +1712,7 @@ reqs           =
     { "type", "name", "range", "present", "quiet"
       "Tech", "Radio", "Player", TRUE, FALSE
       "TerrainClass", "Land", "Local", TRUE, FALSE
-      "UnitFlag", "CanWork", "Local", TRUE, FALSE
+      "UnitFlag", "CanWork", "Local", TRUE, TRUE
       "CityTile", "Center", "Local", FALSE, TRUE
     }
 disappearance_reqs =
@@ -1760,7 +1761,7 @@ reqs           =
       "Extra", "Airstrip", "Local", TRUE, FALSE
       "Tech", "Radio", "Player", TRUE, FALSE
       "TerrainClass", "Land", "Local", TRUE, FALSE
-      "UnitFlag", "CanWork", "Local", TRUE, FALSE
+      "UnitFlag", "CanWork", "Local", TRUE, TRUE
       "Extra", "River", "Local", FALSE, FALSE
       "CityTile", "Center", "Local", FALSE, TRUE
     }
@@ -1891,7 +1892,7 @@ rmact_gfx      = "None"
 rmact_gfx_alt  = "-"
 reqs           =
     { "type", "name", "range", "present", "quiet"
-      "UnitFlag", "CanWork", "Local", TRUE, FALSE
+      "UnitFlag", "CanWork", "Local", TRUE, TRUE
       "TerrainClass", "Land", "Local", TRUE, FALSE
     }
 build_time     = 0
@@ -1927,7 +1928,7 @@ reqs           =
     { "type", "name", "range", "present", "quiet"
       "Tech", "Railroad", "Player", TRUE, FALSE
       "Extra", "Road", "Local", TRUE, FALSE
-      "UnitFlag", "CanWork", "Local", TRUE, FALSE
+      "UnitFlag", "CanWork", "Local", TRUE, TRUE
       "TerrainClass", "Land", "Local", TRUE, FALSE
     }
 build_time     = 3
@@ -1965,7 +1966,7 @@ reqs           =
     { "type", "name", "range", "present", "quiet"
       "Tech", "Superconductors", "Player", TRUE, FALSE
       "Extra", "Railroad", "Local", TRUE, FALSE
-      "UnitFlag", "CanWork", "Local", TRUE, FALSE
+      "UnitFlag", "CanWork", "Local", TRUE, TRUE
       "TerrainClass", "Land", "Local", TRUE, FALSE
     }
 build_time     = 3
@@ -2037,10 +2038,10 @@ reqs           =
       "Tech", "Explosives", "Player", TRUE, FALSE
       "TerrainClass", "Land", "Local", TRUE, FALSE
       "Terrain", "Glacier", "Local", FALSE, FALSE
-      "Terrain", "Hills", "Local", FALSE, FALSE
       "Terrain", "Mountains", "Local", FALSE, FALSE
+      "Terrain", "Hills", "Local", FALSE, FALSE
       "TerrainClass", "Oceanic", "CAdjacent", TRUE, FALSE
-      "UnitFlag", "CanWork", "Local", TRUE, FALSE
+      "UnitFlag", "CanWork", "Local", TRUE, TRUE
       "DiplRelTile", "Foreign", "Local", FALSE, FALSE
     }
 build_time     = 9
@@ -2163,11 +2164,11 @@ rmact_gfx_alt  = "-"
 ;visibility_req = "Industrialization"
 buildable      = FALSE
 conflicts      = "Niter", "Rubber", "Uranium"
-flags          = "TerrChangeRemoves"
+;flags          = "TerrChangeRemoves"
 helptext       = _("\
-Strategic resource, required in a city to build the wonder Apollo \
-Program. Cities with available aluminum build Carrier, AEGIS Cruiser, \
-Cruise Missile, Fighter and Bomber units with one extra veteran level.\
+Strategic resource. Cities with available aluminum build Carrier, \
+AEGIS Cruiser, Cruise Missile, Fighter and Bomber units with one extra \
+veteran level.\
 "), _("\
 With the discovery of Industrialization, aluminum produces 2 extra shields \
 in the tile (hills or tundra).\
@@ -2188,7 +2189,7 @@ rmact_gfx_alt  = "-"
 ;visibility_req = "Gunpowder"
 buildable      = FALSE
 conflicts      = "Aluminum", "Rubber", "Uranium"
-flags          = "TerrChangeRemoves"
+;flags          = "TerrChangeRemoves"
 helptext       = _("\
 Strategic resource. Cities without available niter build gunpowder \
 based units with one less veteran level: Musketeers, Riflemen, Alpine \
@@ -2214,11 +2215,11 @@ rmact_gfx_alt  = "-"
 ;visibility_req = "Chemistry"
 buildable      = FALSE
 conflicts      = "Aluminum", "Niter", "Uranium"
-flags          = "TerrChangeRemoves"
+;flags          = "TerrChangeRemoves"
 helptext       = _("\
-Strategic resource, required in a city to build the wonder SETI Program. \
-Cities with available rubber build Marines, Paratroopers, Helicopter, \
-Mech. Inf. and Howitzer units with one extra veteran level.\
+Strategic resource. Cities with available rubber build Marines, \
+Paratroopers, Helicopter, Mech. Inf. and Howitzer units with one extra \
+veteran level.\
 "), _("\
 With the discovery of Chemistry, rubber produces 2 extra shields in \
 the tile (jungle, swamp or forest).\
@@ -2239,7 +2240,7 @@ rmact_gfx_alt  = "-"
 ;visibility_req = "Atomic Theory"
 buildable      = FALSE
 conflicts      = "Aluminum", "Niter", "Rubber"
-flags          = "TerrChangeRemoves"
+;flags          = "TerrChangeRemoves"
 helptext       = _("\
 Strategic resource, required in a city to build a Nuclear Plant or \
 the wonder Manhattan Project. Cities with available uranium build \

--- a/3.1/civ2civ3_earth/units.ruleset
+++ b/3.1/civ2civ3_earth/units.ruleset
@@ -61,7 +61,7 @@ Cannot move to rough terrain (mountains, jungles and swamps) unless \
 there is a road or base on the tile. If they start the turn on rough \
 terrain or rivers without friendly roads, they have -1 movement point.\
 ")
-    _("Tank")
+    _("Attacker")
     _("Unbribable")
     _("TradeRoute")
     _("HelpWonder")
@@ -641,7 +641,13 @@ tp_defense    = "Alight"
 bombard_rate  = 1
 embarks       = "Helicopter"
 disembarks    = "Helicopter"
-flags         = "OneAttack", "Capturer", "Bombarder", "Settlers"
+bonuses       =
+; Net effect is null, but it encourages AI to build them
+   { "flag", "type", "value", "quiet"
+     "Attacker", "DefenseMultiplier", 3, TRUE
+     "Attacker", "DefenseDivider", 3, TRUE
+   }
+flags         = "OneAttack", "Capturer", "Bombarder", "Attacker", "Settlers"
 roles         = "DefendOk", "DefendOkStartUnit", "Hut"
 helptext      = _("\
 Archers fight with bows and arrows and have a good offensive value.\
@@ -690,7 +696,13 @@ city_slots    = 1
 tp_defense    = "Alight"
 embarks       = "Helicopter"
 disembarks    = "Helicopter"
-flags         = "OneAttack", "Raider", "Capturer",
+bonuses       =
+; Net effect is null, but it encourages AI to build them
+   { "flag", "type", "value", "quiet"
+     "Attacker", "DefenseMultiplier", 3, TRUE
+     "Attacker", "DefenseDivider", 3, TRUE
+   }
+flags         = "OneAttack", "Raider", "Capturer", "Attacker",
                 "Iron", "Settlers"
 roles         = "DefendOk", "DefendOkStartUnit", "BarbarianBuild", "BarbarianSea"
 helptext      = _("\
@@ -1085,10 +1097,11 @@ of any land unit.\
 "),
 ; /* xgettext:no-c-format */
 _("\
-As with other units in this class: they only get defense bonuses from \
-terrain outside cities and bases, and up to a maximum of +25%; they \
-can bombard from coastal land to sea; and they can cause loss of \
-population when attacking a city without City Walls.\
+As with other units in this class: they don't get the defense bonus \
+from rivers, they only get defense bonuses from terrain outside cities, \
+and up to a maximum of +25%; they can bombard non-native tiles (including \
+coastal sea); and they can cause loss of population when attacking \
+a city without City Walls.\
 ")
 
 [unit_horsemen]
@@ -1118,7 +1131,13 @@ uk_food       = 1
 uk_gold       = 1
 city_slots    = 1
 tp_defense    = "Alight"
-flags         = "Capturer", "Horse"
+bonuses       =
+; Net effect is null, but it encourages AI to build them
+   { "flag", "type", "value", "quiet"
+     "Attacker", "DefenseMultiplier", 3, TRUE
+     "Attacker", "DefenseDivider", 3, TRUE
+   }
+flags         = "Capturer", "Attacker", "Horse"
 roles         = "AttackFastStartUnit", "Hut", "Barbarian", "Hunter"
 helptext      = _("\
 Horsemen are mounted warriors and an early shock-troop that can \
@@ -1156,7 +1175,13 @@ uk_food       = 1
 uk_gold       = 1
 city_slots    = 1
 tp_defense    = "Alight"
-flags         = "Wheeled", "Horse"
+bonuses       =
+; Net effect is null, but it encourages AI to build them
+   { "flag", "type", "value", "quiet"
+     "Attacker", "DefenseMultiplier", 3, TRUE
+     "Attacker", "DefenseDivider", 3, TRUE
+   }
+flags         = "Wheeled", "Attacker", "Horse"
 roles         = "AttackFastStartUnit"
 helptext      = _("\
 Chariots are horse-pulled war wagons, stronger but more expensive \
@@ -1164,10 +1189,10 @@ than horsemen.\
 "),
 ; /* xgettext:no-c-format */
 _("\
-As with other units in this class: they only get defense bonuses from \
-terrain outside cities and bases, and up to a maximum of +25%; they \
-can bombard from coastal land to sea; and they can cause loss of \
-population when attacking a city without City Walls.\
+As with other units in this class: they don't get the defense bonus \
+from rivers, they only get defense bonuses from terrain outside cities, \
+and up to a maximum of +25%; they can cause loss of population when \
+attacking a city without City Walls.\
 ")
 
 [unit_elephants]
@@ -1197,7 +1222,13 @@ uk_food       = 1
 uk_gold       = 1
 city_slots    = 1
 tp_defense    = "Alight"
-flags         = "Capturer", "Ivory"
+bonuses       =
+; Net effect is null, but it encourages AI to build them
+   { "flag", "type", "value", "quiet"
+     "Attacker", "DefenseMultiplier", 3, TRUE
+     "Attacker", "DefenseDivider", 3, TRUE
+   }
+flags         = "Capturer", "Attacker", "Ivory"
 roles         = "DefendOk", "AttackFastStartUnit", "Hunter"
 helptext      = _("\
 Elephants are towering animals trained for war that are often used as \
@@ -1231,7 +1262,13 @@ uk_food       = 1
 uk_gold       = 1
 city_slots    = 1
 tp_defense    = "Alight"
-flags         = "Capturer", "Iron", "Horse"
+bonuses       =
+; Net effect is null, but it encourages AI to build them
+   { "flag", "type", "value", "quiet"
+     "Attacker", "DefenseMultiplier", 3, TRUE
+     "Attacker", "DefenseDivider", 3, TRUE
+   }
+flags         = "Capturer", "Attacker", "Iron", "Horse"
 roles         = "DefendOk", "AttackFastStartUnit", "Hunter"
 helptext      = _("\
 Crusaders are highly disciplined mounted warriors driven by a higher \
@@ -1267,7 +1304,13 @@ uk_food       = 1
 uk_gold       = 1
 city_slots    = 1
 tp_defense    = "Alight"
-flags         = "Capturer", "Iron", "Horse"
+bonuses       =
+; Net effect is null, but it encourages AI to build them
+   { "flag", "type", "value", "quiet"
+     "Attacker", "DefenseMultiplier", 3, TRUE
+     "Attacker", "DefenseDivider", 3, TRUE
+   }
+flags         = "Capturer", "Attacker", "Iron", "Horse"
 roles         = "DefendOk", "AttackFastStartUnit", "HutTech", "BarbarianTech",
                 "BarbarianBuildTech", "Hunter"
 helptext      = _("\
@@ -1302,7 +1345,13 @@ uk_gold       = 1
 city_slots    = 1
 tp_defense    = "Alight"
 bombard_rate  = 2
-flags         = "Capturer", "Bombarder", "Horse", "Niter"
+bonuses       =
+; Net effect is null, but it encourages AI to build them
+   { "flag", "type", "value", "quiet"
+     "Attacker", "DefenseMultiplier", 3, TRUE
+     "Attacker", "DefenseDivider", 3, TRUE
+   }
+flags         = "Capturer", "Bombarder", "Attacker", "Horse", "Niter"
 roles         = "DefendOk", "AttackFastStartUnit", "BarbarianTech", "BarbarianBuildTech", "Hunter"
 helptext      = _("\
 Dragoons are mounted warriors carrying early firearms.\
@@ -1336,7 +1385,13 @@ uk_gold       = 1
 city_slots    = 1
 tp_defense    = "Alight"
 bombard_rate  = 2
-flags         = "Capturer", "Bombarder", "Horse", "Niter"
+bonuses       =
+; Net effect is null, but it encourages AI to build them
+   { "flag", "type", "value", "quiet"
+     "Attacker", "DefenseMultiplier", 3, TRUE
+     "Attacker", "DefenseDivider", 3, TRUE
+   }
+flags         = "Capturer", "Bombarder", "Attacker", "Horse", "Niter"
 roles         = "DefendOk", "AttackFastStartUnit", "Hunter"
 helptext      = _("\
 Cavalry are mounted and highly trained soldiers.\
@@ -1373,10 +1428,10 @@ bombard_rate  = 3
 bonuses       =
 ; Net effect is null, but it encourages AI to build them
    { "flag", "type", "value", "quiet"
-     "Tank", "DefenseMultiplier", 3, TRUE
-     "Tank", "DefenseDivider", 3, TRUE
+     "Attacker", "DefenseMultiplier", 3, TRUE
+     "Attacker", "DefenseDivider", 3, TRUE
    }
-flags         = "Bombarder", "Wheeled", "Tank", "Iron_Oil", "Uranium"
+flags         = "Bombarder", "Wheeled", "Attacker", "Iron_Oil", "Uranium"
 roles         = "DefendOk", "AttackFastStartUnit", "Hunter"
 helptext      = _("\
 Armors are motorized war wagons that are faster, stronger, and can take \
@@ -1384,10 +1439,11 @@ more damage than any mounted unit.\
 "),
 ; /* xgettext:no-c-format */
 _("\
-As with other units in this class: they only get defense bonuses from \
-terrain outside cities and bases, and up to a maximum of +25%; they \
-can bombard from coastal land to sea; and they can cause loss of \
-population when attacking a city without City Walls.\
+As with other units in this class: they don't get the defense bonus \
+from rivers, they only get defense bonuses from terrain outside cities, \
+and up to a maximum of +25%; they can bombard non-native tiles (including \
+coastal sea); and they can cause loss of population when attacking \
+a city without City Walls.\
 ")
 
 [unit_catapult]
@@ -1418,7 +1474,13 @@ uk_gold       = 1
 city_slots    = 1
 tp_defense    = "Alight"
 bombard_rate  = 2
-flags         = "Bombarder", "Wheeled"
+bonuses       =
+; Net effect is null, but it encourages AI to build them
+   { "flag", "type", "value", "quiet"
+     "Attacker", "DefenseMultiplier", 3, TRUE
+     "Attacker", "DefenseDivider", 3, TRUE
+   }
+flags         = "Bombarder", "Wheeled", "Attacker"
 roles         = "AttackStrongStartUnit"
 helptext      = _("\
 Catapults are large rock-throwing machines of war. They are very \
@@ -1427,10 +1489,11 @@ to be effective.\
 "),
 ; /* xgettext:no-c-format */
 _("\
-As with other units in this class: they only get defense bonuses from \
-terrain outside cities and bases, and up to a maximum of +25%; they \
-can bombard from coastal land to sea; and they can cause loss of \
-population when attacking a city without City Walls.\
+As with other units in this class: they don't get the defense bonus \
+from rivers, they only get defense bonuses from terrain outside cities, \
+and up to a maximum of +25%; they can bombard non-native tiles (including \
+coastal sea); and they can cause loss of population when attacking \
+a city without City Walls.\
 "), _("\
 Catapults and archers are the only ancient units with the ability to \
 bombard.\
@@ -1475,7 +1538,13 @@ uk_gold       = 1
 city_slots    = 1
 tp_defense    = "Alight"
 bombard_rate  = 3
-flags         = "Bombarder", "Wheeled", "Iron", "Niter"
+bonuses       =
+; Net effect is null, but it encourages AI to build them
+   { "flag", "type", "value", "quiet"
+     "Attacker", "DefenseMultiplier", 3, TRUE
+     "Attacker", "DefenseDivider", 3, TRUE
+   }
+flags         = "Bombarder", "Wheeled", "Attacker", "Iron", "Niter"
 roles         = "AttackStrongStartUnit", "BarbarianBuildTech"
 helptext      = _("\
 Cannons are large firearms that can fire heavy projectiles over long \
@@ -1485,10 +1554,11 @@ effective, and have limited mobility.\
 "),
 ; /* xgettext:no-c-format */
 _("\
-As with other units in this class: they only get defense bonuses from \
-terrain outside cities and bases, and up to a maximum of +25%; they \
-can bombard from coastal land to sea; and they can cause loss of \
-population when attacking a city without City Walls.\
+As with other units in this class: they don't get the defense bonus \
+from rivers, they only get defense bonuses from terrain outside cities, \
+and up to a maximum of +25%; they can bombard non-native tiles (including \
+coastal sea); and they can cause loss of population when attacking \
+a city without City Walls.\
 ")
 
 [unit_artillery]
@@ -1519,7 +1589,13 @@ uk_gold       = 1
 city_slots    = 1
 tp_defense    = "Alight"
 bombard_rate  = 3
-flags         = "CityBuster", "Bombarder", "Wheeled",
+bonuses       =
+; Net effect is null, but it encourages AI to build them
+   { "flag", "type", "value", "quiet"
+     "Attacker", "DefenseMultiplier", 3, TRUE
+     "Attacker", "DefenseDivider", 3, TRUE
+   }
+flags         = "CityBuster", "Bombarder", "Wheeled", "Attacker",
                 "Iron"
 roles         = "AttackStrongStartUnit"
 helptext      = _("\
@@ -1529,10 +1605,11 @@ to be effective, and has limited mobility.\
 "),
 ; /* xgettext:no-c-format */
 _("\
-As with other units in this class: they only get defense bonuses from \
-terrain outside cities and bases, and up to a maximum of +25%; they \
-can bombard from coastal land to sea; and they can cause loss of \
-population when attacking a city without City Walls.\
+As with other units in this class: they don't get the defense bonus \
+from rivers, they only get defense bonuses from terrain outside cities, \
+and up to a maximum of +25%; they can bombard non-native tiles (including \
+coastal sea); and they can cause loss of population when attacking \
+a city without City Walls.\
 "), _("\
 This unit gets double firepower when attacking cities.\
 ")
@@ -1565,7 +1642,13 @@ uk_gold       = 1
 city_slots    = 1
 tp_defense    = "Alight"
 bombard_rate  = 4
-flags         = "CityBuster", "Bombarder", "Wheeled",
+bonuses       =
+; Net effect is null, but it encourages AI to build them
+   { "flag", "type", "value", "quiet"
+     "Attacker", "DefenseMultiplier", 3, TRUE
+     "Attacker", "DefenseDivider", 3, TRUE
+   }
+flags         = "CityBuster", "Bombarder", "Wheeled", "Attacker",
                 "Iron_Oil", "Rubber"
 roles         = "AttackStrongStartUnit"
 helptext      = _("\
@@ -1575,10 +1658,11 @@ of their predecessors.\
 "),
 ; /* xgettext:no-c-format */
 _("\
-As with other units in this class: they only get defense bonuses from \
-terrain outside cities and bases, and up to a maximum of +25%; they \
-can bombard from coastal land to sea; and they can cause loss of \
-population when attacking a city without City Walls.\
+As with other units in this class: they don't get the defense bonus \
+from rivers, they only get defense bonuses from terrain outside cities, \
+and up to a maximum of +25%; they can bombard non-native tiles (including \
+coastal sea); and they can cause loss of population when attacking \
+a city without City Walls.\
 "), _("\
 This unit gets double firepower when attacking cities.\
 ")
@@ -1626,6 +1710,10 @@ turns, it can automatically attack or bombard an incoming enemy.\
 _("\
 As with other aircraft: they lose 10% of their hit points for every \
 turn not spent in a city, airstrip, or airbase, or on a Carrier.\
+"), _("\
+TIP: When a fighter ends its turn in the open, you can use the Goto \
+action to automatically move it to a city or airbase, in order to prevent \
+it from auto-attacking and running out of fuel.\
 ")
 
 [unit_bomber]
@@ -2230,7 +2318,7 @@ bonuses       =
 flags         = "BadCityDefender", "Submarine", "Bombarder", "HPFullSea",
                 "HP20", "HasNoZOC", "Iron_Oil", "Uranium", "AutoAtt",
                 "NeverProtects"
-roles         = "Hunter", "DefendOk", "DefendOkStartUnit"
+roles         = "Hunter", "DefendOk"
 helptext      = _("\
 Traveling under the surface of the ocean, Submarines have a very high \
 strategic value, but a weak defense if caught off guard.\


### PR DESCRIPTION
- Fix the script that checks the new victory condition of SETI Program.
- Wheeled units outside cities (no matter if inside bases) receive the defense bonus from terrain (not from rivers), but only up to +25%.
- Galleys receive the defense bonus from Deep Oceans (like all other naval units, except Submarines).
- Corruption and waste by distance is +4% per tile for Anarchy, Despotism and Tribalism; Trade tech cancels the output per tile penalty (no longer affected by Railroad tech and Pyramids wonder).
- No longer required Aluminum for Apollo Program, nor Rubber for SETI Program.
- Encourage AI to build more attacking units (using fake DefenseMultiplier and DefenseDivider).